### PR TITLE
client-web: refactor code as contexts and components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ name = "artifex-client-web"
 version = "0.1.1"
 dependencies = [
  "gloo",
+ "gloo-console",
  "prost",
  "tonic",
  "tonic-build",

--- a/artifex-client-web/Cargo.toml
+++ b/artifex-client-web/Cargo.toml
@@ -8,6 +8,7 @@ description = "Artifex client program (web application)"
 
 [dependencies]
 gloo = "0.8.0"
+gloo-console = "0.2.3"
 prost = "0.11.2"
 tonic = { version = "0.8.2", default-features = false, features = ["prost", "codegen"] }
 tonic-web-wasm-client = "0.3.3"

--- a/artifex-client-web/src/components/inspection.rs
+++ b/artifex-client-web/src/components/inspection.rs
@@ -1,0 +1,107 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use tonic_web_wasm_client::Client;
+use yew::prelude::*;
+
+use crate::artifex_rpc::{artifex_client::ArtifexClient, InspectRequest};
+use crate::contexts::ServerContext;
+
+fn create_client(url: &str) -> ArtifexClient<Client> {
+    let client = Client::new(url.to_string());
+    ArtifexClient::new(client)
+}
+
+pub enum InspectionState {
+    Failure(String),
+    Idle,
+    Ongoing,
+    Success(String),
+}
+
+pub enum Msg {
+    Inspect,
+    SetInspectionState(InspectionState),
+    ServerUpdated(ServerContext),
+}
+
+pub struct Inspection {
+    server: ServerContext,
+    state: InspectionState,
+    _listener: ContextHandle<ServerContext>,
+}
+
+impl Component for Inspection {
+    type Message = Msg;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let (server, listener) = ctx
+            .link()
+            .context(ctx.link().callback(Msg::ServerUpdated))
+            .expect("No server provided");
+        Self {
+            server,
+            state: InspectionState::Idle,
+            _listener: listener,
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::Inspect => {
+                let mut client = create_client(&self.server.url);
+                ctx.link().send_future(async move {
+                    let state = match client.inspect(InspectRequest {}).await {
+                        Ok(reply) => {
+                            let reply = reply.into_inner();
+                            InspectionState::Success(format!(
+                                "Kernel version: {}",
+                                reply.kernel_version
+                            ))
+                        }
+                        Err(e) => InspectionState::Failure(e.to_string()),
+                    };
+                    Msg::SetInspectionState(state)
+                });
+                ctx.link()
+                    .send_message(Msg::SetInspectionState(InspectionState::Ongoing));
+                false
+            }
+            Msg::SetInspectionState(state) => {
+                self.state = state;
+                true
+            }
+            Msg::ServerUpdated(server) => {
+                self.server = server;
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let onclick = ctx.link().callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::Inspect
+        });
+        let output = match &self.state {
+            InspectionState::Failure(text) => format!("Inspection failed: {}", text),
+            InspectionState::Idle => "".to_string(),
+            InspectionState::Ongoing => "Inspection in progress..".to_string(),
+            InspectionState::Success(text) => text.clone(),
+        };
+        html! {
+            <div class="server-operations">
+              <form>
+                <label for="inspect">{"Inspect machine:"}</label>
+                <button id="inspect" { onclick }>{"Inspect"}</button>
+                </form>
+              <br />
+              <textarea rows=10 cols=80 readonly=true value={ output } />
+            </div>
+        }
+    }
+}

--- a/artifex-client-web/src/components/mod.rs
+++ b/artifex-client-web/src/components/mod.rs
@@ -4,9 +4,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-pub mod artifex_rpc {
-    tonic::include_proto!("artifex");
-}
+mod inspection;
+mod settings;
 
-pub mod components;
-pub mod contexts;
+pub use inspection::Inspection;
+pub use settings::Settings;

--- a/artifex-client-web/src/components/settings.rs
+++ b/artifex-client-web/src/components/settings.rs
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+use crate::contexts::{ServerContext, DEFAULT_URL};
+
+#[function_component]
+pub fn Settings() -> Html {
+    let server = use_context::<ServerContext>().expect("Failed to get server context");
+    let url = server.url.clone();
+    let oninput = Callback::from(move |e: InputEvent| {
+        let input: HtmlInputElement = e.target_unchecked_into();
+        server.dispatch(input.value())
+    });
+    html! {
+        <div class="server-information">
+          <form>
+            <label for="server-url">{"Server URL:"}</label>
+            <input id="server-url" type="text" { oninput }
+                   placeholder={ DEFAULT_URL }
+                   value={ url } />
+          </form>
+       </div>
+    }
+}

--- a/artifex-client-web/src/contexts/mod.rs
+++ b/artifex-client-web/src/contexts/mod.rs
@@ -4,9 +4,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-pub mod artifex_rpc {
-    tonic::include_proto!("artifex");
-}
+mod server;
 
-pub mod components;
-pub mod contexts;
+pub use server::{ServerContext, ServerProvider, DEFAULT_URL};

--- a/artifex-client-web/src/contexts/server.rs
+++ b/artifex-client-web/src/contexts/server.rs
@@ -1,0 +1,44 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use std::rc::Rc;
+use yew::prelude::*;
+
+pub const DEFAULT_URL: &str = "http://[::1]:50051";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Server {
+    pub url: String,
+}
+
+impl Reducible for Server {
+    type Action = String;
+
+    fn reduce(self: Rc<Self>, action: Self::Action) -> Rc<Self> {
+        Server { url: action }.into()
+    }
+}
+
+pub type ServerContext = UseReducerHandle<Server>;
+
+#[derive(Debug, PartialEq, Properties)]
+pub struct ServerProviderProps {
+    #[prop_or_default]
+    pub children: Children,
+}
+
+#[function_component]
+pub fn ServerProvider(props: &ServerProviderProps) -> Html {
+    let server = use_reducer(|| Server {
+        url: DEFAULT_URL.to_string(),
+    });
+
+    html! {
+        <ContextProvider<ServerContext> context={server}>
+            {props.children.clone()}
+        </ContextProvider<ServerContext>>
+    }
+}

--- a/artifex-client-web/src/main.rs
+++ b/artifex-client-web/src/main.rs
@@ -4,117 +4,25 @@
 // SPDX-License-Identifier: MIT
 //
 
-use artifex_client_web::artifex_rpc::{artifex_client::ArtifexClient, InspectRequest};
-use tonic_web_wasm_client::Client;
-use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
-const ARTIFEX_SERVER_URL: &'static str = "http://[::1]:50051";
+use artifex_client_web::{
+    components::{Inspection, Settings},
+    contexts::ServerProvider,
+};
 
-fn create_client(url: &str) -> ArtifexClient<Client> {
-    let client = Client::new(url.to_string());
-    ArtifexClient::new(client)
-}
-
-enum InspectionState {
-    Failure(String),
-    Idle,
-    Ongoing,
-    Success(String),
-}
-
-enum Msg {
-    UrlChanged(String),
-    Inspect,
-    SetInspectionState(InspectionState),
-}
-
-struct App {
-    server_url: String,
-    inspection: InspectionState,
-}
-
-impl Component for App {
-    type Message = Msg;
-    type Properties = ();
-
-    fn create(_ctx: &Context<Self>) -> Self {
-        Self {
-            server_url: ARTIFEX_SERVER_URL.to_string(),
-            inspection: InspectionState::Idle,
-        }
-    }
-
-    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
-        match msg {
-            Msg::UrlChanged(address) => {
-                self.server_url = address;
-                true
-            }
-            Msg::Inspect => {
-                let mut client = create_client(&self.server_url);
-                ctx.link().send_future(async move {
-                    let state = match client.inspect(InspectRequest {}).await {
-                        Ok(reply) => {
-                            let reply = reply.into_inner();
-                            InspectionState::Success(format!(
-                                "Kernel version: {}",
-                                reply.kernel_version
-                            ))
-                        }
-                        Err(e) => InspectionState::Failure(e.to_string()),
-                    };
-                    Msg::SetInspectionState(state)
-                });
-                ctx.link()
-                    .send_message(Msg::SetInspectionState(InspectionState::Ongoing));
-                false
-            }
-            Msg::SetInspectionState(state) => {
-                self.inspection = state;
-                true
-            }
-        }
-    }
-
-    fn view(&self, ctx: &Context<Self>) -> Html {
-        let oninput = ctx.link().callback(|e: InputEvent| {
-            let input: HtmlInputElement = e.target_unchecked_into();
-            Msg::UrlChanged(input.value())
-        });
-        let onclick = ctx.link().callback(|e: MouseEvent| {
-            e.prevent_default();
-            Msg::Inspect
-        });
-        let output = match &self.inspection {
-            InspectionState::Failure(text) => format!("Inspection failed: {}", text),
-            InspectionState::Idle => "".to_string(),
-            InspectionState::Ongoing => "Inspection in progress..".to_string(),
-            InspectionState::Success(text) => text.clone(),
-        };
-        html! {
+#[function_component]
+fn App() -> Html {
+    html! {
         <div>
-            <h1>{ "Artifex Server Management" }</h1>
-            <div class="server-management">
-                <div class="server-information">
-                    <form>
-                    <label for="server-url">{"Server URL:"}</label>
-                    <input id="server-url" type="text" { oninput }
-                           placeholder={ ARTIFEX_SERVER_URL }
-                           value={ self.server_url.clone()} />
-                    </form>
-                </div>
-                <div class="server-operations">
-                    <form>
-                    <label for="inspect">{"Inspect machine:"}</label>
-                    <button id="inspect" { onclick }>{"Inspect"}</button>
-                    </form>
-                    <br />
-                    <textarea rows=10 cols=80 readonly=true
-                              value={ output } />
-                </div>
-            </div>
-        </div> }
+          <h1>{ "Artifex Server Management" }</h1>
+          <div class="server-management">
+            <ServerProvider>
+              <Settings />
+              <Inspection />
+            </ServerProvider>
+          </div>
+        </div>
     }
 }
 


### PR DESCRIPTION
This pull request reworks the Yew-based web client to split the code across contexts and components.