### PR TITLE
Refactor client-web RPC, use IPv4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "yew",
+ "yew-hooks",
 ]
 
 [[package]]
@@ -1744,6 +1745,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "yew-macro",
+]
+
+[[package]]
+name = "yew-hooks"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268e2367720311f19582235f5c021702d6be8ded13b7ee8dcacc71019d055d15"
+dependencies = [
+ "gloo",
+ "js-sys",
+ "log",
+ "serde",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "yew",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ cargo run -p artifex-client
 
 # License
 
-Copyright (c) 2022 Eric Le Bihan
+Copyright © 2022-2023 Eric Le Bihan
 
 This program is distributed under the terms of the MIT License.
 
 See the [LICENSE](LICENSE) file for license details.
 
-[GRPC] https://grpc.io
+[GRPC]: https://grpc.io

--- a/artifex-client-cli/src/main.rs
+++ b/artifex-client-cli/src/main.rs
@@ -10,7 +10,9 @@ use tokio_stream::StreamExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut client = ArtifexClient::connect("http://[::1]:50051").await.unwrap();
+    let mut client = ArtifexClient::connect("http://127.0.0.1:50051")
+        .await
+        .unwrap();
 
     let response = client.inspect(InspectRequest {}).await?;
     let reply = response.into_inner();

--- a/artifex-client-web/Cargo.toml
+++ b/artifex-client-web/Cargo.toml
@@ -16,6 +16,7 @@ wasm-bindgen = "0.2.84"
 wasm-bindgen-futures = "0.4.34"
 web-sys = { version = "0.3.61", features = ["Headers", "Request", "RequestInit", "RequestMode", "Response", "Window"] }
 yew = { version = "0.20.0", features = ["csr"] }
+yew-hooks = "0.2.0"
 
 [build-dependencies]
 tonic-build = { version = "0.8.2", default-features = false, features = ["prost"] }

--- a/artifex-client-web/src/components/inspection.rs
+++ b/artifex-client-web/src/components/inspection.rs
@@ -4,16 +4,10 @@
 // SPDX-License-Identifier: MIT
 //
 
-use tonic_web_wasm_client::Client;
 use yew::prelude::*;
 
-use crate::artifex_rpc::{artifex_client::ArtifexClient, InspectRequest};
 use crate::contexts::ServerContext;
-
-fn create_client(url: &str) -> ArtifexClient<Client> {
-    let client = Client::new(url.to_string());
-    ArtifexClient::new(client)
-}
+use crate::rpc::{create_client, InspectRequest};
 
 pub enum InspectionState {
     Failure(String),

--- a/artifex-client-web/src/components/settings.rs
+++ b/artifex-client-web/src/components/settings.rs
@@ -7,7 +7,7 @@
 use web_sys::HtmlInputElement;
 use yew::prelude::*;
 
-use crate::contexts::{ServerContext, DEFAULT_URL};
+use crate::contexts::ServerContext;
 
 #[function_component]
 pub fn Settings() -> Html {
@@ -22,7 +22,6 @@ pub fn Settings() -> Html {
           <form>
             <label for="server-url">{"Server URL:"}</label>
             <input id="server-url" type="text" { oninput }
-                   placeholder={ DEFAULT_URL }
                    value={ url } />
           </form>
        </div>

--- a/artifex-client-web/src/contexts/mod.rs
+++ b/artifex-client-web/src/contexts/mod.rs
@@ -6,4 +6,4 @@
 
 mod server;
 
-pub use server::{ServerContext, ServerProvider, DEFAULT_URL};
+pub use server::{ServerContext, ServerProvider};

--- a/artifex-client-web/src/contexts/server.rs
+++ b/artifex-client-web/src/contexts/server.rs
@@ -6,8 +6,9 @@
 
 use std::rc::Rc;
 use yew::prelude::*;
+use yew_hooks::prelude::*;
 
-pub const DEFAULT_URL: &str = "http://[::1]:50051";
+pub const DEFAULT_PORT: u16 = 50051;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Server {
@@ -32,8 +33,9 @@ pub struct ServerProviderProps {
 
 #[function_component]
 pub fn ServerProvider(props: &ServerProviderProps) -> Html {
+    let location = use_location();
     let server = use_reducer(|| Server {
-        url: DEFAULT_URL.to_string(),
+        url: format!("http://{}:{}", location.hostname, DEFAULT_PORT),
     });
 
     html! {

--- a/artifex-client-web/src/lib.rs
+++ b/artifex-client-web/src/lib.rs
@@ -4,8 +4,16 @@
 // SPDX-License-Identifier: MIT
 //
 
-pub mod artifex_rpc {
+pub mod rpc {
     tonic::include_proto!("artifex");
+
+    use tonic_web_wasm_client::Client;
+
+    /// Create a client for gRPC server.
+    pub fn create_client(url: &str) -> self::artifex_client::ArtifexClient<Client> {
+        let client = Client::new(url.to_string());
+        self::artifex_client::ArtifexClient::new(client)
+    }
 }
 
 pub mod components;

--- a/artifex-server/src/main.rs
+++ b/artifex-server/src/main.rs
@@ -100,7 +100,7 @@ impl Artifex for ArtifexService {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let address = "[::1]:50051".parse().unwrap();
+    let address = "127.0.0.1:50051".parse().unwrap();
     let artifex = ArtifexService::default();
     let server = ArtifexServer::new(artifex);
 


### PR DESCRIPTION
This pull requests refactors client-web RPC as well as updates server and client-cli to use IPv4 instead of IPv6.