### PR TITLE
client-web: add tabs support, command execution

### DIFF
--- a/artifex-client-web/src/components/execution.rs
+++ b/artifex-client-web/src/components/execution.rs
@@ -1,0 +1,112 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+use crate::contexts::ServerContext;
+use crate::rpc::{create_client, ExecuteRequest};
+
+pub enum ExecutionState {
+    Failure(String),
+    Idle,
+    Ongoing,
+    Success(String),
+}
+
+pub enum Msg {
+    CommandChanged(String),
+    Execute,
+    SetExecutionState(ExecutionState),
+    ServerUpdated(ServerContext),
+}
+
+pub struct Execution {
+    server: ServerContext,
+    state: ExecutionState,
+    _listener: ContextHandle<ServerContext>,
+    command: String,
+}
+
+impl Component for Execution {
+    type Message = Msg;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let (server, listener) = ctx
+            .link()
+            .context(ctx.link().callback(Msg::ServerUpdated))
+            .expect("No server provided");
+        Self {
+            server,
+            state: ExecutionState::Idle,
+            _listener: listener,
+            command: String::new(),
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::CommandChanged(command) => {
+                self.command = command;
+                true
+            }
+            Msg::Execute => {
+                let mut client = create_client(&self.server.url);
+                let command = self.command.clone();
+                ctx.link().send_future(async move {
+                    let state = match client.execute(ExecuteRequest { command }).await {
+                        Ok(reply) => {
+                            let reply = reply.into_inner();
+                            ExecutionState::Success(reply.stdout.clone())
+                        }
+                        Err(e) => ExecutionState::Failure(e.to_string()),
+                    };
+                    Msg::SetExecutionState(state)
+                });
+                ctx.link()
+                    .send_message(Msg::SetExecutionState(ExecutionState::Ongoing));
+                false
+            }
+            Msg::SetExecutionState(state) => {
+                self.state = state;
+                true
+            }
+            Msg::ServerUpdated(server) => {
+                self.server = server;
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let oninput = ctx.link().callback(|e: InputEvent| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            Msg::CommandChanged(input.value())
+        });
+        let onclick = ctx.link().callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::Execute
+        });
+        let output = match &self.state {
+            ExecutionState::Failure(text) => format!("Execution failed: {}", text),
+            ExecutionState::Idle => "".to_string(),
+            ExecutionState::Ongoing => "Execution in progress..".to_string(),
+            ExecutionState::Success(text) => text.clone(),
+        };
+        html! {
+            <div class="server-operations">
+              <form>
+                <label for="command">{"Execute command:"}</label>
+                <input id="command" type="text" { oninput }/>
+                <button id="execute" { onclick }>{"Execute"}</button>
+                </form>
+              <br />
+              <textarea rows=10 cols=80 readonly=true value={ output } />
+            </div>
+        }
+    }
+}

--- a/artifex-client-web/src/components/execution.rs
+++ b/artifex-client-web/src/components/execution.rs
@@ -104,7 +104,6 @@ impl Component for Execution {
                 <input id="command" type="text" { oninput }/>
                 <button id="execute" { onclick }>{"Execute"}</button>
                 </form>
-              <br />
               <textarea rows=10 cols=80 readonly=true value={ output } />
             </div>
         }

--- a/artifex-client-web/src/components/inspection.rs
+++ b/artifex-client-web/src/components/inspection.rs
@@ -93,7 +93,6 @@ impl Component for Inspection {
                 <label for="inspect">{"Inspect machine:"}</label>
                 <button id="inspect" { onclick }>{"Inspect"}</button>
                 </form>
-              <br />
               <textarea rows=10 cols=80 readonly=true value={ output } />
             </div>
         }

--- a/artifex-client-web/src/components/mod.rs
+++ b/artifex-client-web/src/components/mod.rs
@@ -4,11 +4,13 @@
 // SPDX-License-Identifier: MIT
 //
 
+mod execution;
 mod inspection;
 mod settings;
 mod tab;
 mod tab_list;
 
+pub use execution::Execution;
 pub use inspection::Inspection;
 pub use settings::Settings;
 pub use tab::Tab;

--- a/artifex-client-web/src/components/mod.rs
+++ b/artifex-client-web/src/components/mod.rs
@@ -6,6 +6,10 @@
 
 mod inspection;
 mod settings;
+mod tab;
+mod tab_list;
 
 pub use inspection::Inspection;
 pub use settings::Settings;
+pub use tab::Tab;
+pub use tab_list::TabList;

--- a/artifex-client-web/src/components/tab.rs
+++ b/artifex-client-web/src/components/tab.rs
@@ -1,0 +1,21 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use yew::prelude::*;
+
+#[derive(Properties, PartialEq)]
+pub struct TabProps {
+    pub title: String,
+    #[prop_or_default]
+    pub children: Children,
+}
+
+#[function_component(Tab)]
+pub fn tab(props: &TabProps) -> Html {
+    html! {
+        { for props.children.clone() }
+    }
+}

--- a/artifex-client-web/src/components/tab_list.rs
+++ b/artifex-client-web/src/components/tab_list.rs
@@ -1,0 +1,72 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use yew::prelude::*;
+
+use super::tab::Tab;
+
+#[derive(Clone, PartialEq, Properties)]
+pub struct TabListProps {
+    #[prop_or_default]
+    pub children: ChildrenWithProps<Tab>,
+}
+
+pub struct TabList {
+    active_page: usize,
+}
+
+pub enum Msg {
+    SwitchPage(usize),
+}
+
+impl Component for TabList {
+    type Properties = TabListProps;
+    type Message = Msg;
+
+    fn create(ctx: &Context<Self>) -> Self {
+        TabList { active_page: 0 }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::SwitchPage(index) => {
+                self.active_page = index;
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let tabs = ctx.props().children.iter().enumerate().map(|(i, child)| {
+            let is_active = i == self.active_page;
+            let onclick = ctx.link().callback(move |_| Msg::SwitchPage(i));
+            let title = child.props.title.clone();
+
+            html! {
+                <button role="tab" aria-selected={ if is_active { "true" } else { "false" } } { onclick }
+                         aria-controls={ format!("tabpanel-{}", i)} >
+                <span class="focus">{ title }</span>
+               </button>
+            }
+        });
+        let tab_panels = ctx.props().children.iter().enumerate().map(|(i, child)| {
+            let is_active = i == self.active_page;
+            let tab_panel_class = if is_active { "" } else { "hidden" };
+            html! {
+                <div id={ format!("tabpanel-{}", i) } role="tabpanel" class={tab_panel_class}>
+                    {child.clone()}
+                </div>
+            }
+        });
+
+        html! {
+            <div role="tablist">
+                {for tabs}
+                {for tab_panels}
+            </div>
+        }
+    }
+}

--- a/artifex-client-web/src/main.rs
+++ b/artifex-client-web/src/main.rs
@@ -7,7 +7,7 @@
 use yew::prelude::*;
 
 use artifex_client_web::{
-    components::{Inspection, Settings},
+    components::{Inspection, Settings, Tab, TabList},
     contexts::ServerProvider,
 };
 
@@ -19,7 +19,11 @@ fn App() -> Html {
           <div class="server-management">
             <ServerProvider>
               <Settings />
-              <Inspection />
+              <TabList>
+                <Tab title="Inspection" >
+                  <Inspection />
+                </Tab>
+              </TabList>
             </ServerProvider>
           </div>
         </div>

--- a/artifex-client-web/src/main.rs
+++ b/artifex-client-web/src/main.rs
@@ -7,7 +7,7 @@
 use yew::prelude::*;
 
 use artifex_client_web::{
-    components::{Inspection, Settings, Tab, TabList},
+    components::{Execution, Inspection, Settings, Tab, TabList},
     contexts::ServerProvider,
 };
 
@@ -22,6 +22,9 @@ fn App() -> Html {
               <TabList>
                 <Tab title="Inspection" >
                   <Inspection />
+                </Tab>
+                <Tab title="Execution" >
+                  <Execution />
                 </Tab>
               </TabList>
             </ServerProvider>

--- a/artifex-client-web/styles.css
+++ b/artifex-client-web/styles.css
@@ -20,7 +20,7 @@ input[type="text"] {
     padding: 10px;
     border-radius: 5px;
     border: 1px solid #ccc;
-    width: 250px;
+    width: 60%;
 }
 
 button {
@@ -39,14 +39,95 @@ button:hover {
 
 
 textarea {
-    padding: 5px;
+    padding: 5px 0px;
     border-radius: 5px;
     border: 1px solid #ccc;
     resize: none;
-    width: auto;
+    width: 100%;
 }
 
 h1 {
     text-align: center;
     margin-top: 50px;
+}
+
+.hidden {
+    display: none;
+}
+
+[role="tablist"] {
+  min-width: 100%;
+}
+
+[role="tab"],
+[role="tab"]:focus,
+[role="tab"]:hover {
+  display: inline-block;
+  position: relative;
+  z-index: 2;
+  top: 2px;
+  margin: 0;
+  margin-top: 4px;
+  padding: 3px 3px 4px;
+  border: 1px solid hsl(219deg 1% 72%);
+  border-bottom: 2px solid hsl(219deg 1% 72%);
+  border-radius: 5px 5px 0 0;
+  background: hsl(220deg 20% 94%);
+  outline: none;
+  font-weight: bold;
+  max-width: 22%;
+  overflow: hidden;
+  text-align: left;
+  cursor: pointer;
+}
+
+[role="tab"][aria-selected="true"] {
+  padding: 2px 2px 4px;
+  margin-top: 0;
+  border-width: 2px;
+  border-top-width: 6px;
+  border-top-color: rgb(36 116 214);
+  border-bottom-color: hsl(220deg 43% 99%);
+  background: hsl(220deg 43% 99%);
+}
+
+[role="tab"][aria-selected="false"] {
+  border-bottom: 1px solid hsl(219deg 1% 72%);
+}
+
+[role="tab"] span.focus {
+  display: inline-block;
+  margin: 2px;
+  padding: 4px 6px;
+}
+
+[role="tab"]:hover span.focus {
+  padding: 2px 4px;
+  border: 2px solid rgb(36 116 214);
+  border-radius: 3px;
+}
+
+[role="tabpanel"] {
+  padding: 5px;
+  border: 2px solid hsl(219deg 1% 72%);
+  border-radius: 0 5px 5px;
+  background: hsl(220deg 43% 99%);
+  min-height: 10em;
+  width: 100%;
+}
+
+[role="tabpanel"].is-hidden {
+  display: none;
+}
+
+[role="tabpanel"] p {
+  margin: 0;
+}
+
+.server-operations{
+    padding: 5px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
 }


### PR DESCRIPTION
This pull requests updates client-web to organize operations as tabs and adds support for executing commands.