### PR TITLE
client-web: add upgrade operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
 name = "artifex-client-web"
 version = "0.1.1"
 dependencies = [
+ "futures-util",
  "gloo",
  "gloo-console",
  "prost",

--- a/artifex-client-web/Cargo.toml
+++ b/artifex-client-web/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Artifex client program (web application)"
 
 [dependencies]
+futures-util = "0.3.28"
 gloo = "0.8.0"
 gloo-console = "0.2.3"
 prost = "0.11.2"

--- a/artifex-client-web/src/components/mod.rs
+++ b/artifex-client-web/src/components/mod.rs
@@ -9,9 +9,11 @@ mod inspection;
 mod settings;
 mod tab;
 mod tab_list;
+mod upgrade;
 
 pub use execution::Execution;
 pub use inspection::Inspection;
 pub use settings::Settings;
 pub use tab::Tab;
 pub use tab_list::TabList;
+pub use upgrade::Upgrade;

--- a/artifex-client-web/src/components/upgrade.rs
+++ b/artifex-client-web/src/components/upgrade.rs
@@ -1,0 +1,116 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use futures_util::StreamExt;
+use tonic::codec::Streaming;
+use yew::prelude::*;
+
+use crate::{
+    contexts::ServerContext,
+    rpc::{create_client, UpgradeReply, UpgradeRequest},
+};
+
+pub enum UpgradeState {
+    Complete,
+    Failure(String),
+    Idle,
+    Progressed(usize),
+    Started,
+}
+
+pub enum Msg {
+    ServerUpdated(ServerContext),
+    Upgrade,
+    UpgradeFailed(String),
+    UpgradeProgressed(usize),
+    UpgradeStarted(Streaming<UpgradeReply>),
+}
+
+pub struct Upgrade {
+    server: ServerContext,
+    state: UpgradeState,
+    _listener: ContextHandle<ServerContext>,
+}
+
+impl Component for Upgrade {
+    type Message = Msg;
+    type Properties = ();
+
+    fn create(ctx: &Context<Self>) -> Self {
+        let (server, listener) = ctx
+            .link()
+            .context(ctx.link().callback(Msg::ServerUpdated))
+            .expect("No server provided");
+        Self {
+            server,
+            state: UpgradeState::Idle,
+            _listener: listener,
+        }
+    }
+
+    fn update(&mut self, ctx: &Context<Self>, msg: Self::Message) -> bool {
+        match msg {
+            Msg::ServerUpdated(server) => {
+                self.server = server;
+                true
+            }
+            Msg::Upgrade => {
+                let mut client = create_client(&self.server.url);
+                ctx.link().send_future(async move {
+                    match client.upgrade(UpgradeRequest {}).await {
+                        Ok(stream) => Msg::UpgradeStarted(stream.into_inner()),
+                        Err(e) => Msg::UpgradeFailed(e.to_string()),
+                    }
+                });
+                false
+            }
+            Msg::UpgradeFailed(message) => {
+                self.state = UpgradeState::Failure(message);
+                true
+            }
+            Msg::UpgradeProgressed(position) => {
+                self.state = if position == 100 {
+                    UpgradeState::Complete
+                } else {
+                    UpgradeState::Progressed(position)
+                };
+                true
+            }
+            Msg::UpgradeStarted(stream) => {
+                ctx.link().send_stream(stream.map(|item| match item {
+                    Ok(reply) => Msg::UpgradeProgressed(reply.position as usize),
+                    Err(e) => Msg::UpgradeFailed(e.message().to_string()),
+                }));
+                self.state = UpgradeState::Started;
+                true
+            }
+        }
+    }
+
+    fn view(&self, ctx: &Context<Self>) -> Html {
+        let onclick = ctx.link().callback(|e: MouseEvent| {
+            e.prevent_default();
+            Msg::Upgrade
+        });
+        let (value, text) = match &self.state {
+            UpgradeState::Complete => (100, "Success".to_string()),
+            UpgradeState::Failure(message) => (0, format!("Error: {}", message)),
+            UpgradeState::Idle => (0, "".to_string()),
+            UpgradeState::Progressed(position) => (*position, format!("{}%", *position)),
+            UpgradeState::Started => (0, "Started".to_string()),
+        };
+        html! {
+            <div class="server-operations">
+              <form>
+                <label for="start">{"Perform upgrade"}</label>
+                <button id="start" { onclick }>{"Start"}</button>
+              </form>
+              <progress id="progress-bar" role="progress" max="100" value={ value.to_string() } />
+              <label for="progress-bar">{ text }</label>
+            </div>
+        }
+    }
+}

--- a/artifex-client-web/src/main.rs
+++ b/artifex-client-web/src/main.rs
@@ -7,7 +7,7 @@
 use yew::prelude::*;
 
 use artifex_client_web::{
-    components::{Execution, Inspection, Settings, Tab, TabList},
+    components::{Execution, Inspection, Settings, Tab, TabList, Upgrade},
     contexts::ServerProvider,
 };
 
@@ -25,6 +25,9 @@ fn App() -> Html {
                 </Tab>
                 <Tab title="Execution" >
                   <Execution />
+                </Tab>
+                <Tab title="Upgrade" >
+                  <Upgrade />
                 </Tab>
               </TabList>
             </ServerProvider>

--- a/artifex-client-web/styles.css
+++ b/artifex-client-web/styles.css
@@ -51,6 +51,11 @@ h1 {
     margin-top: 50px;
 }
 
+progress {
+    width: 100%;
+    height: 25px;
+}
+
 .hidden {
     display: none;
 }


### PR DESCRIPTION
This pull  request adds a new tab to client-web to perform the upgrade operation. 

The progress of the upgrade is reported by a progress bar.