### PR TITLE
Add support for running batches of commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
 name = "artifex-client-cli"
 version = "0.1.1"
 dependencies = [
+ "artifex-batch",
  "artifex-rpc",
  "futures",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +22,18 @@ name = "anymap2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
+name = "artifex-batch"
+version = "0.1.1"
+dependencies = [
+ "artifex-rpc",
+ "chrono",
+ "futures-util",
+ "thiserror",
+ "tonic",
+ "uuid",
+]
 
 [[package]]
 name = "artifex-client-cli"
@@ -227,6 +248,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-integer",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "console_error_panic_hook"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -234,6 +280,56 @@ checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
  "cfg-if",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cxx"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -390,7 +486,7 @@ checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -681,6 +777,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "implicit-clone"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,7 +935,7 @@ checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.45.0",
 ]
 
@@ -815,6 +944,25 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -1146,6 +1294,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "scratch"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
+
+[[package]]
 name = "serde"
 version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,6 +1429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1292,6 +1455,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1582,6 +1756,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "uuid"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dad5567ad0cf5b760e5665964bec1b47dfd077ba8a2544b513f3556d3d239a2"
+dependencies = [
+ "getrandom",
+ "rand",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1786,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -1720,10 +1916,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets 0.48.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "artifex-batch",
   "artifex-client-cli",
   "artifex-client-web",
   "artifex-engine",

--- a/artifex-batch/Cargo.toml
+++ b/artifex-batch/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "artifex-batch"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Artifex command batch management for clients"
+
+[dependencies]
+artifex-rpc = { path = "../artifex-rpc" }
+tonic = "0.8.2"
+thiserror = "1.0.40"
+futures-util = "0.3.28"
+chrono = "0.4.24"
+uuid = { version = "1.3.2", features = ["v4", "fast-rng"] }

--- a/artifex-batch/src/batch.rs
+++ b/artifex-batch/src/batch.rs
@@ -1,0 +1,97 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use super::command::Command;
+use super::error::Error;
+use std::io::BufRead;
+use std::{
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+    str::FromStr,
+};
+
+/// Represent a batch of commands.
+#[derive(Debug, PartialEq)]
+pub struct Batch {
+    pub(crate) commands: Vec<Command>,
+}
+
+impl FromStr for Batch {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let commands: Result<Vec<Command>, Error> = s
+            .split(';')
+            .map(|s| Command::from_str(s).map_err(Error::Syntax))
+            .collect();
+        Ok(Batch {
+            commands: commands?,
+        })
+    }
+}
+
+impl Batch {
+    /// Build a `Batch` from the contents of a file.
+    pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let file = File::open(path)?;
+        Self::from_reader(file)
+    }
+
+    pub fn from_reader<R: Read>(reader: R) -> Result<Self, Error> {
+        let reader = BufReader::new(reader);
+        let commands: Result<Vec<Command>, Error> = reader
+            .lines()
+            .filter_map(Result::ok)
+            .filter(|l| !l.starts_with('#'))
+            .filter(|l| !l.is_empty())
+            .map(|l| Command::from_str(&l).map_err(Error::Syntax))
+            .collect();
+        Ok(Batch {
+            commands: commands?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_string() {
+        let res = "EXECUTE: date -u; UPGRADE".parse::<Batch>();
+        assert!(res.is_ok());
+        assert_eq!(
+            res.unwrap(),
+            Batch {
+                commands: vec![Command::Execute("date -u".to_string()), Command::Upgrade]
+            }
+        );
+    }
+
+    const BATCH_VALID: &str = r##"
+INSPECT
+# Comment
+EXECUTE: date -u
+UPGRADE
+"##;
+
+    #[test]
+    fn parse_valid_text() {
+        let res = Batch::from_reader(BATCH_VALID.as_bytes());
+        assert!(res.is_ok());
+        assert_eq!(
+            res.unwrap(),
+            Batch {
+                commands: vec![
+                    Command::Inspect,
+                    Command::Execute("date -u".to_string()),
+                    Command::Upgrade
+                ]
+            }
+        );
+    }
+}

--- a/artifex-batch/src/command.rs
+++ b/artifex-batch/src/command.rs
@@ -1,0 +1,94 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use std::{fmt::Display, str::FromStr};
+use thiserror::Error;
+
+/// Errors raised when handling a `Command`.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Empty string")]
+    EmptyString,
+    #[error("Missing argument")]
+    MissingArgument,
+    #[error("Unknown command: {0}")]
+    UnknownCommand(String),
+}
+
+/// Represent a command to be execute via a client.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Command {
+    Execute(String),
+    Inspect,
+    Upgrade,
+}
+
+impl FromStr for Command {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.is_empty() {
+            return Err(Error::EmptyString);
+        }
+        let items = s.trim().split(':').collect::<Vec<&str>>();
+        match items[0] {
+            "EXECUTE" => {
+                if items.len() != 2 {
+                    Err(Error::MissingArgument)
+                } else {
+                    Ok(Command::Execute(items[1].trim().to_string()))
+                }
+            }
+            "INSPECT" => Ok(Command::Inspect),
+            "UPGRADE" => Ok(Command::Upgrade),
+            _ => Err(Error::UnknownCommand(s.to_string())),
+        }
+    }
+}
+
+impl Display for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Command::Execute(command) => write!(f, "EXECUTE: {}", command),
+            Command::Inspect => write!(f, "INSPECT"),
+            Command::Upgrade => write!(f, "UPGRADE"),
+        }
+    }
+}
+
+/// Hold the output the execution of a command.
+#[derive(Debug, PartialEq)]
+pub enum CommandOutput {
+    String(String),
+    Uint32(u32),
+}
+
+impl Display for CommandOutput {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommandOutput::String(s) => write!(f, "{}", s),
+            CommandOutput::Uint32(u) => write!(f, "{}", u),
+        }
+    }
+}
+
+/// Represent the status of the execution of a command.
+#[derive(Debug, PartialEq)]
+pub enum CommandStatus {
+    Success(Option<CommandOutput>),
+    Failure,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_execute() {
+        let res = "EXECUTE: date -u".parse::<Command>();
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), Command::Execute("date -u".to_string()))
+    }
+}

--- a/artifex-batch/src/error.rs
+++ b/artifex-batch/src/error.rs
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use thiserror::Error;
+
+/// Errors raised when processing a batch.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Formatting error: {0}")]
+    Fmt(#[from] std::fmt::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("RPC error: {0}")]
+    Rpc(#[from] tonic::Status),
+    #[error("Syntax error: {0}")]
+    Syntax(#[from] super::command::Error),
+}

--- a/artifex-batch/src/lib.rs
+++ b/artifex-batch/src/lib.rs
@@ -1,0 +1,16 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+mod batch;
+mod command;
+mod error;
+mod report;
+mod runner;
+
+pub use batch::Batch;
+pub use error::Error;
+pub use report::{BatchReport, MarkupKind, MarkupReportRenderer};
+pub use runner::BatchRunner;

--- a/artifex-batch/src/report.rs
+++ b/artifex-batch/src/report.rs
@@ -1,0 +1,162 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use chrono::prelude::*;
+use std::io::Write;
+
+use crate::command::{Command, CommandOutput, CommandStatus};
+use crate::error::Error;
+
+/// Hold information about the execution of a command.
+#[derive(Debug)]
+pub struct ReportEntry {
+    pub command: Command,
+    pub status: CommandStatus,
+}
+
+#[derive(Debug)]
+pub struct BatchReport {
+    date: DateTime<Utc>,
+    title: String,
+    entries: Vec<ReportEntry>,
+}
+
+impl BatchReport {
+    /// Create a new report.
+    pub(crate) fn new(title: &str) -> Self {
+        Self {
+            date: Utc::now(),
+            title: title.to_string(),
+            entries: vec![],
+        }
+    }
+
+    /// Append a new report entry with information about the execution of a command.
+    pub(crate) fn push(&mut self, entry: ReportEntry) {
+        self.entries.push(entry);
+    }
+
+    /// Return the creation date of a `Report`.
+    pub fn date(&self) -> &DateTime<Utc> {
+        &self.date
+    }
+
+    /// Return the entries in a `Report`.
+    pub fn entries(&self) -> &[ReportEntry] {
+        &self.entries
+    }
+
+    /// Return the title of a `Report`.
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    #[cfg(test)]
+    pub(crate) fn spoof_date(&mut self, date: &str) -> Result<(), chrono::format::ParseError> {
+        let date = DateTime::parse_from_rfc3339(date)?;
+        self.date = date.into();
+        Ok(())
+    }
+}
+
+/// Convert a `Report` to a text representation using a markup format.
+#[derive(Debug)]
+pub struct MarkupReportRenderer {
+    markup_kind: MarkupKind,
+}
+
+/// Kind of supported markup formats.
+#[derive(Debug)]
+pub enum MarkupKind {
+    Yaml,
+}
+
+impl MarkupReportRenderer {
+    /// Create a new report renderer.
+    pub fn new(markup_kind: MarkupKind) -> Self {
+        Self { markup_kind }
+    }
+
+    /// Render a report.
+    pub fn render<W: Write>(&self, writer: &mut W, report: &BatchReport) -> Result<(), Error> {
+        match self.markup_kind {
+            MarkupKind::Yaml => Self::render_as_yaml(writer, report),
+        }
+    }
+
+    fn render_as_yaml<W: Write>(writer: &mut W, report: &BatchReport) -> Result<(), Error> {
+        writeln!(writer, "# Artifex batch report")?;
+        write!(
+            writer,
+            "title   : {}\ndate    : {}\ncommands:\n",
+            report.title(),
+            report.date().to_rfc3339()
+        )?;
+        for entry in report.entries() {
+            writeln!(writer, "- command: '{}'", entry.command)?;
+            let (status, output) = match &entry.status {
+                CommandStatus::Failure => ("failure", None),
+                CommandStatus::Success(output) => ("success", output.as_ref()),
+            };
+            writeln!(writer, "  status : {}", status)?;
+            if let Some(output) = output {
+                writeln!(writer, "  output : |")?;
+                match output {
+                    CommandOutput::String(text) => {
+                        for line in text.lines() {
+                            writeln!(writer, "    {}", line)?;
+                        }
+                    }
+                    CommandOutput::Uint32(number) => {
+                        writeln!(writer, "    {}", number)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::command::CommandOutput;
+
+    const REPORT_YAML: &str = r#"# Artifex batch report
+title   : Dummy Report
+date    : 2023-05-07T09:17:58.133639582+00:00
+commands:
+- command: 'EXECUTE: date -u'
+  status : success
+  output : |
+    Sun May  7 09:17:58 UTC 2023
+- command: 'UPGRADE'
+  status : failure
+"#;
+    #[test]
+    fn render_to_yaml() {
+        let mut report = BatchReport::new("Dummy Report");
+        report
+            .spoof_date("2023-05-07T09:17:58.133639582+00:00")
+            .unwrap();
+        report.push(ReportEntry {
+            command: Command::Execute("date -u".to_string()),
+            status: CommandStatus::Success(Some(CommandOutput::String(
+                "Sun May  7 09:17:58 UTC 2023".to_string(),
+            ))),
+        });
+        report.push(ReportEntry {
+            command: Command::Upgrade,
+            status: CommandStatus::Failure,
+        });
+        let renderer = MarkupReportRenderer::new(MarkupKind::Yaml);
+        let mut buffer: Vec<u8> = vec![];
+        let res = renderer.render(&mut buffer, &report);
+        assert!(res.is_ok());
+        let text = String::from_utf8(buffer).unwrap();
+        assert_eq!(REPORT_YAML, text);
+    }
+}

--- a/artifex-batch/src/runner.rs
+++ b/artifex-batch/src/runner.rs
@@ -1,0 +1,92 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use crate::{
+    batch::Batch,
+    command::{Command, CommandOutput, CommandStatus},
+    error::Error,
+    report::{BatchReport, ReportEntry},
+};
+
+use artifex_rpc::{artifex_client::ArtifexClient, ExecuteRequest, InspectRequest, UpgradeRequest};
+use futures_util::StreamExt;
+use std::fmt::Write;
+use uuid::Uuid;
+
+/// Run commands via a client.
+#[derive(Debug)]
+pub(crate) struct CommandRunner {
+    client: ArtifexClient<tonic::transport::Channel>,
+}
+
+impl CommandRunner {
+    /// Run a command and return its output.
+    pub(crate) async fn run(&mut self, command: &Command) -> Result<CommandStatus, Error> {
+        let status = match command {
+            Command::Execute(command) => {
+                let response = self
+                    .client
+                    .execute(ExecuteRequest {
+                        command: command.to_string(),
+                    })
+                    .await?;
+                let reply = response.into_inner();
+                CommandStatus::Success(Some(CommandOutput::String(reply.stdout)))
+            }
+            Command::Inspect => {
+                let response = self.client.inspect(InspectRequest {}).await?;
+                let reply = response.into_inner();
+                let output = format!("kernel version: {}", reply.kernel_version);
+                CommandStatus::Success(Some(CommandOutput::String(output)))
+            }
+            Command::Upgrade => {
+                let response = self.client.upgrade(UpgradeRequest {}).await?;
+                let mut output = String::new();
+                let mut stream = response.into_inner();
+                while let Some(reply) = stream.next().await {
+                    let progress = reply?;
+                    writeln!(
+                        output,
+                        "Upgrade progress: {:?}, {}%",
+                        progress.status(),
+                        progress.position
+                    )?;
+                }
+                CommandStatus::Success(Some(CommandOutput::String(output)))
+            }
+        };
+        Ok(status)
+    }
+}
+
+/// Allow to run batches of commands via a client.
+#[derive(Debug)]
+pub struct BatchRunner {
+    inner: CommandRunner,
+}
+
+impl BatchRunner {
+    /// Build a `BatchRunner` associated to a `ArtifexClient`
+    pub fn new(client: ArtifexClient<tonic::transport::Channel>) -> Self {
+        Self {
+            inner: CommandRunner { client },
+        }
+    }
+
+    /// Run a batch of commands
+    pub async fn run(&mut self, batch: &Batch) -> Result<BatchReport, Error> {
+        let title = format!("Report - {}", Uuid::new_v4());
+        let mut report = BatchReport::new(&title);
+        for command in &batch.commands {
+            let status = self.inner.run(command).await?;
+            report.push(ReportEntry {
+                command: command.clone(),
+                status,
+            });
+        }
+        Ok(report)
+    }
+}

--- a/artifex-client-cli/Cargo.toml
+++ b/artifex-client-cli/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Artifex client program (command line)"
 
 [dependencies]
+artifex-batch = { path = "../artifex-batch" }
 artifex-rpc = { path = "../artifex-rpc" }
 futures = "0.3.25"
 tokio = { version = "1.21.2", features = ["full"] }


### PR DESCRIPTION
This pull request adds a new crate named `artifex-batch` to allow running batches of commands defined in a text file via a client and updates `artifex-client-cli` to run a batch.