### PR TITLE
Add command line options to server and CLI client 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,7 @@ dependencies = [
 name = "artifex-server"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "artifex-engine",
  "artifex-rpc",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +140,7 @@ version = "0.1.1"
 dependencies = [
  "artifex-engine",
  "artifex-rpc",
+ "clap",
  "futures",
  "http",
  "tokio",
@@ -264,6 +314,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+ "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+
+[[package]]
 name = "codespan-reporting"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +364,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console_error_panic_hook"
@@ -841,6 +939,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1877,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,7 @@ dependencies = [
 name = "artifex-client-cli"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "artifex-batch",
  "artifex-rpc",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ version = "0.1.1"
 dependencies = [
  "artifex-batch",
  "artifex-rpc",
+ "clap",
  "futures",
  "tokio",
  "tokio-stream",

--- a/artifex-client-cli/Cargo.toml
+++ b/artifex-client-cli/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 description = "Artifex client program (command line)"
 
 [dependencies]
+anyhow = "1.0.71"
 artifex-batch = { path = "../artifex-batch" }
 artifex-rpc = { path = "../artifex-rpc" }
 clap = { version = "4.2.7", features = ["derive"] }

--- a/artifex-client-cli/Cargo.toml
+++ b/artifex-client-cli/Cargo.toml
@@ -9,6 +9,7 @@ description = "Artifex client program (command line)"
 [dependencies]
 artifex-batch = { path = "../artifex-batch" }
 artifex-rpc = { path = "../artifex-rpc" }
+clap = { version = "4.2.7", features = ["derive"] }
 futures = "0.3.25"
 tokio = { version = "1.21.2", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }

--- a/artifex-server/Cargo.toml
+++ b/artifex-server/Cargo.toml
@@ -17,3 +17,4 @@ tonic-reflection = "0.6.0"
 tonic-web = "0.5.0"
 tower-http = { version = "0.3.5", features = ["cors"] }
 http = "0.2.8"
+clap = { version = "4.2.7", features = ["derive"] }

--- a/artifex-server/Cargo.toml
+++ b/artifex-server/Cargo.toml
@@ -18,3 +18,4 @@ tonic-web = "0.5.0"
 tower-http = { version = "0.3.5", features = ["cors"] }
 http = "0.2.8"
 clap = { version = "4.2.7", features = ["derive"] }
+anyhow = "1.0.71"

--- a/artifex-server/src/lib.rs
+++ b/artifex-server/src/lib.rs
@@ -1,0 +1,7 @@
+//
+// Copyright (C) 2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+pub mod service;

--- a/artifex-server/src/main.rs
+++ b/artifex-server/src/main.rs
@@ -4,16 +4,30 @@
 // SPDX-License-Identifier: MIT
 //
 
+use std::net::SocketAddr;
+
 use artifex_rpc::{artifex_server::ArtifexServer, FILE_DESCRIPTOR_SET};
 use artifex_server::service::ArtifexService;
+use clap::Parser;
 use http::Method;
 use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;
 use tower_http::cors::{Any, CorsLayer};
 
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    #[arg(short, long, help = "Address to use", default_value = "127.0.0.1")]
+    address: String,
+
+    #[arg(short, long, help = "Port to use", default_value_t = 50051)]
+    port: u16,
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let address = "127.0.0.1:50051".parse()?;
+    let args = Cli::parse();
+    let address = SocketAddr::new(args.address.parse()?, args.port);
     let artifex = ArtifexService::default();
     let server = ArtifexServer::new(artifex);
 

--- a/artifex-server/src/main.rs
+++ b/artifex-server/src/main.rs
@@ -4,109 +4,22 @@
 // SPDX-License-Identifier: MIT
 //
 
-use artifex_engine::Engine;
-use artifex_rpc::{
-    artifex_server::{Artifex, ArtifexServer},
-    upgrade_reply, ExecuteReply, ExecuteRequest, InspectReply, InspectRequest, UpgradeReply,
-    UpgradeRequest, FILE_DESCRIPTOR_SET,
-};
-
-use futures::Stream;
+use artifex_rpc::{artifex_server::ArtifexServer, FILE_DESCRIPTOR_SET};
+use artifex_server::service::ArtifexService;
 use http::Method;
-use std::sync::Mutex;
-use std::{pin::Pin, sync::Arc};
-use tokio::sync::mpsc;
-use tokio::task;
-use tokio_stream::wrappers::ReceiverStream;
-use tonic::{transport::Server, Request, Response, Status};
+use tonic::transport::Server;
 use tonic_web::GrpcWebLayer;
 use tower_http::cors::{Any, CorsLayer};
 
-#[derive(Default)]
-pub struct ArtifexService {
-    engine: Arc<Mutex<Engine>>,
-}
-
-#[tonic::async_trait]
-impl Artifex for ArtifexService {
-    type UpgradeStream = Pin<Box<dyn Stream<Item = Result<UpgradeReply, Status>> + Send>>;
-
-    async fn inspect(
-        &self,
-        _request: Request<InspectRequest>,
-    ) -> Result<Response<InspectReply>, Status> {
-        let engine = self.engine.lock().unwrap();
-        let info = engine.inspect().unwrap();
-        let response = InspectReply {
-            kernel_version: info.kernel_version,
-        };
-        Ok(Response::new(response))
-    }
-
-    async fn execute(
-        &self,
-        request: Request<ExecuteRequest>,
-    ) -> Result<Response<ExecuteReply>, Status> {
-        let execute_req = request.into_inner();
-        let mut args = execute_req.command.split_whitespace();
-        let engine = self.engine.lock().unwrap();
-        let program = args.next().unwrap();
-        let output = engine.execute(program, args).unwrap();
-        let response = ExecuteReply {
-            code: output.code,
-            stdout: output.stdout,
-            stderr: output.stderr,
-        };
-        Ok(Response::new(response))
-    }
-
-    async fn upgrade(
-        &self,
-        _request: Request<UpgradeRequest>,
-    ) -> Result<Response<Self::UpgradeStream>, Status> {
-        let (tx, rx) = mpsc::channel(100);
-        let engine = self.engine.clone();
-        let tx_clone = tx.clone();
-        task::spawn_blocking(move || {
-            let engine = engine.lock().unwrap();
-            let res = engine.upgrade(move |position| {
-                let reply = UpgradeReply {
-                    status: upgrade_reply::Status::Running as i32,
-                    position: position as i32,
-                };
-                if tx_clone
-                    .blocking_send(Result::<_, Status>::Ok(reply))
-                    .is_err()
-                {
-                }
-            });
-            let status = if res.is_ok() {
-                upgrade_reply::Status::Success as i32
-            } else {
-                upgrade_reply::Status::Failure as i32
-            };
-            let reply = UpgradeReply {
-                status,
-                position: 100,
-            };
-            let _ = tx.blocking_send(Result::<_, Status>::Ok(reply));
-        });
-
-        let ostream = ReceiverStream::new(rx);
-        Ok(Response::new(Box::pin(ostream) as Self::UpgradeStream))
-    }
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let address = "127.0.0.1:50051".parse().unwrap();
+    let address = "127.0.0.1:50051".parse()?;
     let artifex = ArtifexService::default();
     let server = ArtifexServer::new(artifex);
 
     let reflection = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
-        .build()
-        .unwrap();
+        .build()?;
 
     let cors = CorsLayer::new()
         .allow_methods([Method::POST])

--- a/artifex-server/src/service.rs
+++ b/artifex-server/src/service.rs
@@ -1,0 +1,93 @@
+//
+// Copyright (C) 2022-2023 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use artifex_engine::Engine;
+use artifex_rpc::{
+    artifex_server::Artifex, upgrade_reply, ExecuteReply, ExecuteRequest, InspectReply,
+    InspectRequest, UpgradeReply, UpgradeRequest,
+};
+
+use futures::Stream;
+use std::sync::Mutex;
+use std::{pin::Pin, sync::Arc};
+use tokio::sync::mpsc;
+use tokio::task;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+#[derive(Default)]
+pub struct ArtifexService {
+    engine: Arc<Mutex<Engine>>,
+}
+
+#[tonic::async_trait]
+impl Artifex for ArtifexService {
+    type UpgradeStream = Pin<Box<dyn Stream<Item = Result<UpgradeReply, Status>> + Send>>;
+
+    async fn inspect(
+        &self,
+        _request: Request<InspectRequest>,
+    ) -> Result<Response<InspectReply>, Status> {
+        let engine = self.engine.lock().unwrap();
+        let info = engine.inspect().unwrap();
+        let response = InspectReply {
+            kernel_version: info.kernel_version,
+        };
+        Ok(Response::new(response))
+    }
+
+    async fn execute(
+        &self,
+        request: Request<ExecuteRequest>,
+    ) -> Result<Response<ExecuteReply>, Status> {
+        let execute_req = request.into_inner();
+        let mut args = execute_req.command.split_whitespace();
+        let engine = self.engine.lock().unwrap();
+        let program = args.next().unwrap();
+        let output = engine.execute(program, args).unwrap();
+        let response = ExecuteReply {
+            code: output.code,
+            stdout: output.stdout,
+            stderr: output.stderr,
+        };
+        Ok(Response::new(response))
+    }
+
+    async fn upgrade(
+        &self,
+        _request: Request<UpgradeRequest>,
+    ) -> Result<Response<Self::UpgradeStream>, Status> {
+        let (tx, rx) = mpsc::channel(100);
+        let engine = self.engine.clone();
+        let tx_clone = tx.clone();
+        task::spawn_blocking(move || {
+            let engine = engine.lock().unwrap();
+            let res = engine.upgrade(move |position| {
+                let reply = UpgradeReply {
+                    status: upgrade_reply::Status::Running as i32,
+                    position: position as i32,
+                };
+                if tx_clone
+                    .blocking_send(Result::<_, Status>::Ok(reply))
+                    .is_err()
+                {}
+            });
+            let status = if res.is_ok() {
+                upgrade_reply::Status::Success as i32
+            } else {
+                upgrade_reply::Status::Failure as i32
+            };
+            let reply = UpgradeReply {
+                status,
+                position: 100,
+            };
+            let _ = tx.blocking_send(Result::<_, Status>::Ok(reply));
+        });
+
+        let ostream = ReceiverStream::new(rx);
+        Ok(Response::new(Box::pin(ostream) as Self::UpgradeStream))
+    }
+}


### PR DESCRIPTION
This patch series improves the server and the command line client by using `anyhow` and `clap` to get prettier error messages and add options to:

- set address and port for server.
- set server URL for client.
- read commands from a batch file or standard input for client.
- write report to a file or standard output for client.