### PR TITLE
Add Cargo xtask support, to install Git hooks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+xtask = "run --package xtask --"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2272,6 +2272,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "xshell"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2107fe03e558353b4c71ad7626d58ed82efaf56c54134228608893c77023ad"
+dependencies = [
+ "xshell-macros",
+]
+
+[[package]]
+name = "xshell-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
+
+[[package]]
+name = "xtask"
+version = "0.1.1"
+dependencies = [
+ "xshell",
+]
+
+[[package]]
 name = "yew"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "artifex-rpc",
   "artifex-server",
   "random-progression",
+  "xtask",
 ]
 resolver = "2"
 

--- a/hooks/pre-commit.hook
+++ b/hooks/pre-commit.hook
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# set -euo pipefail
+
+IS_AMEND=$(ps -ocommand= -p ${PPID} | grep -e '--amend');
+
+if [ -n "${IS_AMEND}" ]; then
+    exit 0;
+fi
+
+declare -A checks=(
+    [style]="cargo fmt --all -- --check"
+)
+
+function check() {
+    local label=$1
+    local cmd=$2
+    echo "🔍 Checking ${label}..."
+    eval "${cmd}"
+    if test $? != 0; then
+        echo "❌ Checking ${label} failed!"
+        echo "Please fix the above issues."
+        exit 1
+    else
+        echo "✅ Checking ${label} pass!"
+    fi
+}
+
+for key in "${!checks[@]}"; do
+    check "${key}" "${checks[${key}]}"
+done

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+xshell = "0.2.5"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,49 @@
+//
+// Copyright (C) 2022-2024 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use std::{env, error::Error, fs, os::unix::prelude::PermissionsExt};
+
+use xshell::Shell;
+
+fn install_hooks(shell: &Shell) -> Result<(), Box<dyn Error>> {
+    let cwd = shell.current_dir();
+    let mut src = cwd.join("hooks");
+    src.push("pre-commit.hook");
+    let name = src
+        .file_stem()
+        .ok_or_else(|| "Missing file stem".to_string())?;
+    let mut dst = cwd.join(".git");
+    dst.push("hooks");
+    dst.push(name);
+    shell.copy_file(src, &dst)?;
+    let mut permissions = fs::metadata(&dst)?.permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(dst, permissions)?;
+    Ok(())
+}
+
+fn prepare(shell: &Shell) -> Result<(), Box<dyn Error>> {
+    install_hooks(shell)
+}
+
+fn usage() {
+    eprintln!(
+        r#"Tasks:
+
+prepare  Prepare development environment
+"#
+    );
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let shell = Shell::new()?;
+    let task = env::args().nth(1);
+    match task.as_deref() {
+        Some("prepare") => prepare(&shell)?,
+        _ => usage(),
+    }
+    Ok(())
+}


### PR DESCRIPTION
Add "xtask" crate in workspace which builds a Cargo command conforming to [cargo-xtask](https://github.com/matklad/cargo-xtask/).

Currently, it only provides "prepare" command, to prepare the development environment by installing [Git hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks).