### PR TITLE
batch,rpc: make crates wasm32-compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,8 @@ dependencies = [
  "artifex-rpc",
  "chrono",
  "futures-util",
+ "getrandom",
+ "http-body 1.0.0",
  "humantime",
  "thiserror",
  "tonic",
@@ -209,8 +211,8 @@ dependencies = [
  "bitflags 1.3.2",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "hyper",
  "itoa",
  "matchit",
@@ -235,8 +237,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "mime",
  "rustversion",
  "tower-layer",
@@ -506,13 +508,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -532,7 +536,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
  "indexmap 2.1.0",
  "slab",
  "tokio",
@@ -585,14 +589,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -630,8 +655,8 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "httparse",
  "httpdate",
  "itoa",
@@ -1302,8 +1327,8 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "hyper",
  "hyper-timeout",
  "percent-encoding",
@@ -1351,8 +1376,8 @@ checksum = "dc3b0e1cedbf19fdfb78ef3d672cb9928e0a91a9cb4629cc0c916e8cff8aaaa1"
 dependencies = [
  "base64",
  "bytes",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "hyper",
  "pin-project",
  "tokio-stream",
@@ -1393,8 +1418,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 0.2.11",
+ "http-body 0.4.5",
  "http-range-header",
  "pin-project-lite",
  "tower-layer",

--- a/artifex-batch/Cargo.toml
+++ b/artifex-batch/Cargo.toml
@@ -8,9 +8,16 @@ description = "Artifex command batch management for clients"
 
 [dependencies]
 artifex-rpc = { path = "../artifex-rpc" }
-tonic = "0.11.0"
 thiserror = "1.0.50"
 futures-util = "0.3.29"
 chrono = "0.4.31"
 uuid = { version = "1.6.1", features = ["v4", "fast-rng"] }
 humantime = "2.1.0"
+http-body = "1.0.0"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tonic = { version = "0.11", default-features = false, features = ["prost", "codegen"] }
+getrandom = {version = "0.2.14", features = ["js"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tonic = "0.11"

--- a/artifex-batch/src/runner.rs
+++ b/artifex-batch/src/runner.rs
@@ -19,11 +19,17 @@ use uuid::Uuid;
 
 /// Run commands via a client.
 #[derive(Debug)]
-pub(crate) struct CommandRunner {
-    client: ArtifexClient<tonic::transport::Channel>,
+pub(crate) struct CommandRunner<T> {
+    client: ArtifexClient<T>,
 }
 
-impl CommandRunner {
+impl<T> CommandRunner<T>
+where
+    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    T::Error: Into<tonic::codegen::StdError>,
+    <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
+{
     /// Run a command and return its output.
     pub(crate) async fn run(&mut self, command: &Command) -> Result<CommandStatus, Error> {
         let status = match command {
@@ -69,13 +75,19 @@ impl CommandRunner {
 
 /// Allow to run batches of commands via a client.
 #[derive(Debug)]
-pub struct BatchRunner {
-    inner: CommandRunner,
+pub struct BatchRunner<T> {
+    inner: CommandRunner<T>,
 }
 
-impl BatchRunner {
+impl<T> BatchRunner<T>
+where
+    T: tonic::client::GrpcService<tonic::body::BoxBody>,
+    T::ResponseBody: tonic::codegen::Body<Data = tonic::codegen::Bytes> + Send + 'static,
+    T::Error: Into<tonic::codegen::StdError>,
+    <T::ResponseBody as tonic::codegen::Body>::Error: Into<tonic::codegen::StdError> + Send,
+{
     /// Build a `BatchRunner` associated to a `ArtifexClient`
-    pub fn new(client: ArtifexClient<tonic::transport::Channel>) -> Self {
+    pub fn new(client: ArtifexClient<T>) -> Self {
         Self {
             inner: CommandRunner { client },
         }

--- a/artifex-rpc/Cargo.toml
+++ b/artifex-rpc/Cargo.toml
@@ -5,9 +5,13 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[dependencies]
+[target.'cfg(target_arch = "wasm32")'.dependencies]
 prost = "0.12.3"
-tonic = "0.11.0"
+tonic = { version = "0.11", default-features = false, features = ["prost", "codegen"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+prost = "0.12.3"
+tonic = "0.11"
 
 [build-dependencies]
-tonic-build = "0.11.0"
+tonic-build = "0.11"

--- a/artifex-rpc/build.rs
+++ b/artifex-rpc/build.rs
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2022 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+// Copyright (C) 2022-2024 Eric Le Bihan <eric.le.bihan.dev@free.fr>
 //
 // SPDX-License-Identifier: MIT
 //
@@ -7,11 +7,18 @@
 use std::{env, error::Error, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
-    tonic_build::configure()
-        .file_descriptor_set_path(out_dir.join("artifex_descriptor.bin"))
-        .compile(&["proto/artifex.proto"], &["proto"])
-        .unwrap();
-    tonic_build::compile_protos("proto/artifex.proto")?;
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH")?;
+    let builder = match target_arch.as_str() {
+        "wasm32" => tonic_build::configure()
+            .build_server(false)
+            .build_client(true)
+            .build_transport(false),
+        _ => {
+            let out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+            tonic_build::configure()
+                .file_descriptor_set_path(out_dir.join("artifex_descriptor.bin"))
+        }
+    };
+    builder.compile(&["proto/artifex.proto"], &["proto"])?;
     Ok(())
 }

--- a/artifex-rpc/src/lib.rs
+++ b/artifex-rpc/src/lib.rs
@@ -6,4 +6,5 @@
 
 tonic::include_proto!("artifex");
 
+#[cfg(not(target_arch = "wasm32"))]
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("artifex_descriptor");


### PR DESCRIPTION
This pull request updates `artifex-rpc` and `artifex-batch` to make them wasm32-compatible.