### PR TITLE
Restrict command execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "getrandom 0.3.1",
  "http-body 1.0.0",
  "humantime",
- "thiserror",
+ "thiserror 1.0.50",
  "tonic",
  "uuid",
 ]
@@ -134,7 +134,7 @@ dependencies = [
  "rand 0.9.0",
  "random-progression",
  "serde",
- "thiserror",
+ "thiserror 1.0.50",
 ]
 
 [[package]]
@@ -155,8 +155,11 @@ dependencies = [
  "artifex-rpc",
  "clap",
  "futures",
+ "serde",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
+ "toml",
  "tonic",
  "tonic-reflection",
  "tonic-web",
@@ -1195,6 +1198,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1280,7 +1292,16 @@ version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.50",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1288,6 +1309,17 @@ name = "thiserror-impl"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1358,6 +1390,47 @@ dependencies = [
  "tokio",
  "tracing",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+dependencies = [
+ "indexmap 2.9.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"
@@ -1804,6 +1877,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "nix",
  "rand 0.9.0",
  "random-progression",
+ "serde",
  "thiserror",
 ]
 
@@ -549,7 +550,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.1.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -564,9 +565,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -727,12 +728,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -914,7 +915,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -1175,18 +1176,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/artifex-engine/Cargo.toml
+++ b/artifex-engine/Cargo.toml
@@ -11,3 +11,4 @@ libc = "0.2.168"
 thiserror = "1.0.50"
 rand = "0.9.0"
 nix = { version = "0.28.0", features = ["feature"] }
+serde = { version = "1.0.219", features = ["derive"] }

--- a/artifex-engine/src/config.rs
+++ b/artifex-engine/src/config.rs
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use serde::Deserialize;
+
+/// Hold the configuration of the engine.
+#[derive(Debug, Default, Deserialize, PartialEq)]
+pub struct Config {
+    pub allowed_programs: Vec<String>,
+}
+
+impl Config {
+    /// Return an iterator over the allowed programs.
+    pub fn allowed_programs(&self) -> impl Iterator<Item = &str> {
+        self.allowed_programs.iter().map(|s| s.as_str())
+    }
+}

--- a/artifex-engine/src/engine.rs
+++ b/artifex-engine/src/engine.rs
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: MIT
 //
 
-use crate::error::Result;
+use crate::config::Config;
+use crate::error::{Error, Result};
 use crate::machine::{get_machine_info, MachineInfo};
 use rand::{self, Rng};
 use random_progression::RandomProgression;
@@ -17,9 +18,16 @@ pub struct ProgramOutput {
 }
 
 #[derive(Default)]
-pub struct Engine;
+pub struct Engine {
+    config: Config,
+}
 
 impl Engine {
+    /// Create a new `Engine` with the configuration `config`.
+    pub fn with_config(config: Config) -> Self {
+        Self { config }
+    }
+
     pub fn inspect(&self) -> Result<MachineInfo> {
         get_machine_info()
     }
@@ -29,12 +37,20 @@ impl Engine {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let output = std::process::Command::new(program).args(args).output()?;
-        Ok(ProgramOutput {
-            code: output.status.code().unwrap_or(-1),
-            stdout: std::str::from_utf8(&output.stdout)?.into(),
-            stderr: std::str::from_utf8(&output.stderr)?.into(),
-        })
+        if let Some(program) = self
+            .config
+            .allowed_programs()
+            .find(|p| *p == program.as_ref())
+        {
+            let output = std::process::Command::new(program).args(args).output()?;
+            Ok(ProgramOutput {
+                code: output.status.code().unwrap_or(-1),
+                stdout: std::str::from_utf8(&output.stdout)?.into(),
+                stderr: std::str::from_utf8(&output.stderr)?.into(),
+            })
+        } else {
+            Err(Error::Internal("Program not allowed".to_string()))
+        }
     }
 
     pub fn upgrade<F>(&self, notify: F) -> Result<()>
@@ -59,7 +75,7 @@ mod tests {
 
     #[test]
     fn do_progressive_stuff() {
-        let engine = Engine {};
+        let engine = Engine::default();
         let res = engine.upgrade(|position| {
             println!("Progression: {}%", position);
         });

--- a/artifex-engine/src/error.rs
+++ b/artifex-engine/src/error.rs
@@ -8,6 +8,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("Internal error: {0}")]
+    Internal(String),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Unix error: {0}")]

--- a/artifex-engine/src/lib.rs
+++ b/artifex-engine/src/lib.rs
@@ -4,10 +4,12 @@
 // SPDX-License-Identifier: MIT
 //
 
+mod config;
 mod engine;
 mod error;
 mod machine;
 
+pub use config::Config;
 pub use engine::Engine;
 pub use error::{Error, Result};
 pub use machine::MachineInfo;

--- a/artifex-server/Cargo.toml
+++ b/artifex-server/Cargo.toml
@@ -17,3 +17,6 @@ tonic-reflection = "0.11.0"
 tonic-web = "0.11.0"
 clap = { version = "4.4.8", features = ["derive"] }
 anyhow = "1.0.75"
+toml = "0.8.22"
+serde = { version = "1.0.219", features = ["derive"] }
+thiserror = "2.0.12"

--- a/artifex-server/data/example/config.toml
+++ b/artifex-server/data/example/config.toml
@@ -1,0 +1,4 @@
+address = "127.0.0.1"
+port = 50051
+[engine]
+allowed_programs = ["date", "uname"]

--- a/artifex-server/src/config.rs
+++ b/artifex-server/src/config.rs
@@ -1,0 +1,69 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use crate::error::Error;
+use artifex_engine::Config as EngineConfig;
+use serde::Deserialize;
+use std::path::Path;
+
+/// Hold the configuration of the engine.
+#[derive(Debug, Deserialize, PartialEq)]
+pub struct Config {
+    /// Address to use.
+    pub address: String,
+    /// Port to use.
+    pub port: u16,
+    /// Configuration of the engine.
+    pub engine: EngineConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            address: Self::DEFAULT_ADDRESS.to_string(),
+            port: Self::DEFAULT_PORT,
+            engine: EngineConfig::default(),
+        }
+    }
+}
+
+impl Config {
+    /// Default server address.
+    pub const DEFAULT_ADDRESS: &str = "127.0.0.1";
+    /// Default server port.
+    pub const DEFAULT_PORT: u16 = 50051;
+    /// Create a new configuration from file at `path`.
+    pub fn with_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+        let text = std::fs::read_to_string(path)?;
+        let config = toml::de::from_str(&text)?;
+        Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONFIG_VALID: &str = r#"
+address = "127.0.0.1"
+port = 50051
+[engine]
+allowed_programs = ["date", "uname"]
+"#;
+
+    #[test]
+    fn parse_config_valid() {
+        let result = toml::de::from_str::<Config>(CONFIG_VALID);
+        assert!(result.is_ok());
+        let reference = Config {
+            engine: EngineConfig {
+                allowed_programs: vec!["date".to_string(), "uname".to_string()],
+            },
+            ..Default::default()
+        };
+        assert_eq!(result.unwrap(), reference);
+    }
+}

--- a/artifex-server/src/error.rs
+++ b/artifex-server/src/error.rs
@@ -1,0 +1,15 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("TOML error: {0}")]
+    Toml(#[from] toml::de::Error),
+}

--- a/artifex-server/src/lib.rs
+++ b/artifex-server/src/lib.rs
@@ -4,4 +4,6 @@
 // SPDX-License-Identifier: MIT
 //
 
+pub mod config;
+pub mod error;
 pub mod service;

--- a/artifex-server/src/main.rs
+++ b/artifex-server/src/main.rs
@@ -6,31 +6,43 @@
 
 use anyhow::{Context, Result};
 use artifex_rpc::{artifex_server::ArtifexServer, FILE_DESCRIPTOR_SET};
-use artifex_server::service::ArtifexService;
+use artifex_server::{config::Config, service::ArtifexService};
 use clap::Parser;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use tonic::transport::Server;
-
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
-    #[arg(short, long, help = "Address to use", default_value = "127.0.0.1")]
-    address: String,
+    #[arg(short, long, help = "Address to use")]
+    address: Option<String>,
 
-    #[arg(short, long, help = "Port to use", default_value_t = 50051)]
-    port: u16,
+    #[arg(short, long, help = "Port to use")]
+    port: Option<u16>,
+
+    #[arg(short = 'C', long, help = "Path to configuration file")]
+    config: Option<PathBuf>,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
+    let config = if let Some(path) = args.config {
+        Config::with_path(path)?
+    } else {
+        Config::default()
+    };
+
     let address = args
         .address
+        .unwrap_or(config.address)
         .parse()
         .with_context(|| "failed to parse address")?;
-    let address = SocketAddr::new(address, args.port);
-    let artifex = ArtifexService::default();
+    let port = args.port.unwrap_or(config.port);
+    let address = SocketAddr::new(address, port);
+
+    let artifex = ArtifexService::with_engine_config(config.engine);
     let server = ArtifexServer::new(artifex);
 
     let reflection = tonic_reflection::server::Builder::configure()

--- a/artifex-server/src/service.rs
+++ b/artifex-server/src/service.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use artifex_engine::Engine;
+use artifex_engine::{Config, Engine};
 use artifex_rpc::{
     artifex_server::Artifex, upgrade_reply, ExecuteReply, ExecuteRequest, InspectReply,
     InspectRequest, UpgradeReply, UpgradeRequest,
@@ -21,6 +21,15 @@ use tonic::{Request, Response, Status};
 #[derive(Default)]
 pub struct ArtifexService {
     engine: Arc<Mutex<Engine>>,
+}
+
+impl ArtifexService {
+    /// Create a new service using an engine configuration.
+    pub fn with_engine_config(config: Config) -> Self {
+        Self {
+            engine: Arc::new(Mutex::new(Engine::with_config(config))),
+        }
+    }
 }
 
 #[tonic::async_trait]

--- a/artifex-server/src/service.rs
+++ b/artifex-server/src/service.rs
@@ -47,14 +47,21 @@ impl Artifex for ArtifexService {
         let execute_req = request.into_inner();
         let mut args = execute_req.command.split_whitespace();
         let engine = self.engine.lock().unwrap();
-        let program = args.next().unwrap();
-        let output = engine.execute(program, args).unwrap();
-        let response = ExecuteReply {
-            code: output.code,
-            stdout: output.stdout,
-            stderr: output.stderr,
-        };
-        Ok(Response::new(response))
+        if let Some(program) = args.next() {
+            engine
+                .execute(program, args)
+                .map_err(|e| Status::internal(e.to_string()))
+                .map(|output| {
+                    let response = ExecuteReply {
+                        code: output.code,
+                        stdout: output.stdout,
+                        stderr: output.stderr,
+                    };
+                    Response::new(response)
+                })
+        } else {
+            Err(Status::invalid_argument("Missing program name"))
+        }
     }
 
     async fn upgrade(


### PR DESCRIPTION
This PR adds support for restricting the list of programs allowed to be executed by the server by:

- adding support for reading the configuration of the server and its underlying engine from a file.
- restrict engine to only allow execution of programs mentioned in its configuration.

By default, no programs are allowed.