### PR TITLE
client-cli: refactor TLS support

### DIFF
--- a/artifex-client-cli/src/client.rs
+++ b/artifex-client-cli/src/client.rs
@@ -6,16 +6,28 @@
 
 //! Client management.
 
-use anyhow::{Context, Result};
 use artifex_rpc::artifex_client::ArtifexClient;
 use hyper_rustls::FixedServerNameResolver;
 use hyper_rustls::HttpsConnectorBuilder;
 use hyper_util::client::legacy::connect::HttpConnector;
+use thiserror::Error;
+use tokio_rustls::rustls;
 use tokio_rustls::rustls::pki_types::ServerName;
 use tonic::transport::{Channel, Endpoint};
 use tower::ServiceBuilder;
 
 use crate::tls::{create_client_config, Config as TlsConfig};
+
+/// Errors reported when managing a client.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("RusTLS error: {0}")]
+    Rustls(#[from] rustls::pki_types::InvalidDnsNameError),
+    #[error("TLS error: {0}")]
+    Tls(#[from] crate::tls::Error),
+    #[error("Tonic transport error: {0}")]
+    Tonic(#[from] tonic::transport::Error),
+}
 
 /// Build a client, with options.
 #[derive(Debug, Default)]
@@ -29,11 +41,10 @@ impl ClientBuilder {
         Self { tls: Some(tls) }
     }
     /// Create a client for server at `url`.
-    pub async fn connect(self, url: &str) -> Result<ArtifexClient<Channel>> {
-        let endpoint = Endpoint::from_shared(url.to_string()).with_context(|| "Invalid URI")?;
+    pub async fn connect(self, url: &str) -> Result<ArtifexClient<Channel>, Error> {
+        let endpoint = Endpoint::from_shared(url.to_string())?;
         let tls = if let Some(tls) = &self.tls {
-            let tls = create_client_config(tls)
-                .with_context(|| "failed to create TLS client configuration")?;
+            let tls = create_client_config(tls)?;
             Some(tls)
         } else {
             None
@@ -66,14 +77,9 @@ impl ClientBuilder {
                 })
                 .map_request(move |_| url.clone())
                 .service(http);
-            Channel::connect(connector, endpoint)
-                .await
-                .with_context(|| "failed to connect to server")?
+            Channel::connect(connector, endpoint).await?
         } else {
-            endpoint
-                .connect()
-                .await
-                .with_context(|| "failed to connect to server")?
+            endpoint.connect().await?
         };
         let client = ArtifexClient::new(conn);
         Ok(client)

--- a/artifex-client-cli/src/config.rs
+++ b/artifex-client-cli/src/config.rs
@@ -8,7 +8,7 @@ use super::password::PasswordProvider;
 use super::tls::Config as TlsConfig;
 use artifex_batch::MarkupKind;
 use serde::Deserialize;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use thiserror::Error;
 
 /// Errors reported when managing the configuration.
@@ -40,7 +40,13 @@ impl Default for Config {
             format: MarkupKind::Yaml,
             url: Self::DEFAULT_URL.to_string(),
             password_provider: PasswordProvider::Prompt,
-            tls: TlsConfig::default(),
+            tls: TlsConfig {
+                root_cert: PathBuf::from(Self::DEFAULT_TLS_ROOT_CERT),
+                client_cert: PathBuf::from(Self::DEFAULT_TLS_CLIENT_CERT),
+                client_key: PathBuf::from(Self::DEFAULT_TLS_CLIENT_KEY),
+                client_password: None,
+                server_alt_name: None,
+            },
         }
     }
 }
@@ -48,6 +54,12 @@ impl Default for Config {
 impl Config {
     /// Default URL to connect to.
     pub const DEFAULT_URL: &str = "https://127.0.0.1:50051";
+    /// Default TLS root certification authority file.
+    pub const DEFAULT_TLS_ROOT_CERT: &str = "/etc/artifex/root.crt.pem";
+    /// Default TLS client certificate.
+    pub const DEFAULT_TLS_CLIENT_CERT: &str = "/etc/artifex/client.crt.pem";
+    /// Default TLS client private key.
+    pub const DEFAULT_TLS_CLIENT_KEY: &str = "/etc/artifex/client.key.pem";
     /// Create a new configuration from file at `path`.
     pub fn with_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let text = std::fs::read_to_string(path)?;

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -48,27 +48,6 @@ pub struct Config {
     pub server_alt_name: Option<String>,
 }
 
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            root_cert: PathBuf::from(Self::DEFAULT_ROOT_CERT),
-            client_cert: PathBuf::from(Self::DEFAULT_CLIENT_CERT),
-            client_key: PathBuf::from(Self::DEFAULT_CLIENT_KEY),
-            client_password: None,
-            server_alt_name: None,
-        }
-    }
-}
-
-impl Config {
-    /// Default root certification authoritity file.
-    pub const DEFAULT_ROOT_CERT: &str = "/etc/artifex/root.crt.pem";
-    /// Default client certificate.
-    pub const DEFAULT_CLIENT_CERT: &str = "/etc/artifex/client.crt.pem";
-    /// Default client private key.
-    pub const DEFAULT_CLIENT_KEY: &str = "/etc/artifex/client.key.pem";
-}
-
 /// Create TLS client configuration.
 pub fn create_client_config(config: &Config) -> Result<ClientConfig, Error> {
     let mut ca_store = RootCertStore::empty();

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -7,7 +7,7 @@
 //! TLS client configuration.
 
 mod client_cert_resolver;
-mod client_signing_key;
+mod file_signing_key;
 
 use anyhow::{Context, Result};
 use serde::Deserialize;

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -9,16 +9,29 @@
 mod client_cert_resolver;
 mod file_signing_key;
 
-use anyhow::{Context, Result};
 use serde::Deserialize;
 use std::{path::PathBuf, sync::Arc};
+use thiserror::Error;
 use tokio_rustls::rustls::{
     self,
-    pki_types::{pem::PemObject, CertificateDer},
+    pki_types::{self, pem::PemObject, CertificateDer},
     ClientConfig, RootCertStore,
 };
 
 use client_cert_resolver::ClientCertResolverBuilder;
+
+/// Errors occuring when configuring TLS connection.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Client certificate resolver error: {0}")]
+    ClientCertResolver(#[from] client_cert_resolver::Error),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("PEM error: {0}")]
+    Pem(#[from] pki_types::pem::Error),
+    #[error("RusTLS error: {0}")]
+    RusTls(#[from] rustls::Error),
+}
 
 /// Hold the configuration of the TLS.
 #[derive(Debug, Deserialize, PartialEq)]
@@ -57,29 +70,19 @@ impl Config {
 }
 
 /// Create TLS client configuration.
-pub fn create_client_config(config: &Config) -> Result<ClientConfig> {
+pub fn create_client_config(config: &Config) -> Result<ClientConfig, Error> {
     let mut ca_store = RootCertStore::empty();
-    let root_cert = CertificateDer::from_pem_file(&config.root_cert).with_context(|| {
-        format!(
-            "Failed to read root certificate from '{}'",
-            config.root_cert.display()
-        )
-    })?;
-    ca_store
-        .add(root_cert)
-        .with_context(|| "Failed to add root certificate")?;
+    let root_cert = CertificateDer::from_pem_file(&config.root_cert)?;
+    ca_store.add(root_cert)?;
     let provider = rustls::crypto::ring::default_provider();
     let mut client_cert_resolver_builder =
         ClientCertResolverBuilder::with_pem_files(&config.client_cert, &config.client_key)?;
     if let Some(password) = &config.client_password {
         client_cert_resolver_builder.password(password);
     }
-    let client_cert_resolver = client_cert_resolver_builder
-        .build()
-        .with_context(|| "Failed to create client certificate resolver")?;
+    let client_cert_resolver = client_cert_resolver_builder.build()?;
     let tls = ClientConfig::builder_with_provider(provider.into())
-        .with_safe_default_protocol_versions()
-        .with_context(|| "Failed to get protocols")?;
+        .with_safe_default_protocol_versions()?;
     let tls = tls
         .with_root_certificates(ca_store)
         .with_client_cert_resolver(Arc::new(client_cert_resolver));

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -14,13 +14,13 @@ use tokio_rustls::rustls::{
     SignatureScheme,
 };
 
-use crate::tls::client_signing_key::ClientSigningKeyBuilder;
+use crate::tls::file_signing_key::FileSigningKeyBuilder;
 
 // A builder for configuring a client client certificate resolver.
 #[derive(Debug)]
 pub(super) struct ClientCertResolverBuilder {
     cert_pem: String,
-    key_builder: ClientSigningKeyBuilder,
+    key_builder: FileSigningKeyBuilder,
 }
 
 impl ClientCertResolverBuilder {
@@ -32,7 +32,7 @@ impl ClientCertResolverBuilder {
                 cert_path.as_ref().display()
             )
         })?;
-        let key_builder = ClientSigningKeyBuilder::with_pem_file(&key_path).with_context(|| {
+        let key_builder = FileSigningKeyBuilder::with_pem_file(&key_path).with_context(|| {
             format!("Failed to read key from '{}'", key_path.as_ref().display())
         })?;
         Ok(Self {

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -4,17 +4,28 @@
 // SPDX-License-Identifier: MIT
 //
 
-use anyhow::{Context, Result};
 use std::path::Path;
 use std::sync::Arc;
+use thiserror::Error;
 use tokio_rustls::rustls::{
     client::ResolvesClientCert,
-    pki_types::{pem::PemObject, CertificateDer},
+    pki_types::{self, pem::PemObject, CertificateDer},
     sign::CertifiedKey,
     SignatureScheme,
 };
 
 use crate::tls::file_signing_key::FileSigningKeyBuilder;
+
+/// Errors occuring when operating with a client certificate resolver.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("PEM error: {0}")]
+    Pem(#[from] pki_types::pem::Error),
+    #[error("Signing key error: {0}")]
+    SigningKey(#[from] crate::tls::file_signing_key::Error),
+}
 
 // A builder for configuring a client client certificate resolver.
 #[derive(Debug)]
@@ -25,16 +36,9 @@ pub(super) struct ClientCertResolverBuilder {
 
 impl ClientCertResolverBuilder {
     /// Create a builder.
-    pub(super) fn with_pem_files<P: AsRef<Path>>(cert_path: P, key_path: P) -> Result<Self> {
-        let cert_pem = std::fs::read_to_string(&cert_path).with_context(|| {
-            format!(
-                "Failed to read certificate from '{}'",
-                cert_path.as_ref().display()
-            )
-        })?;
-        let key_builder = FileSigningKeyBuilder::with_pem_file(&key_path).with_context(|| {
-            format!("Failed to read key from '{}'", key_path.as_ref().display())
-        })?;
+    pub(super) fn with_pem_files<P: AsRef<Path>>(cert_path: P, key_path: P) -> Result<Self, Error> {
+        let cert_pem = std::fs::read_to_string(&cert_path)?;
+        let key_builder = FileSigningKeyBuilder::with_pem_file(&key_path)?;
         Ok(Self {
             cert_pem,
             key_builder,
@@ -46,13 +50,9 @@ impl ClientCertResolverBuilder {
         self
     }
     /// Build a client certificate resolver.
-    pub(super) fn build(self) -> Result<ClientCertResolver> {
-        let cert = CertificateDer::from_pem_reader(self.cert_pem.as_bytes())
-            .with_context(|| "Failed to create certificate")?;
-        let key = self
-            .key_builder
-            .build()
-            .with_context(|| "Failed to create client signing key")?;
+    pub(super) fn build(self) -> Result<ClientCertResolver, Error> {
+        let cert = CertificateDer::from_pem_reader(self.cert_pem.as_bytes())?;
+        let key = self.key_builder.build()?;
         let key = CertifiedKey::new(vec![cert], Arc::new(key));
         Ok(ClientCertResolver { key: Arc::new(key) })
     }

--- a/artifex-client-cli/src/tls/file_signing_key.rs
+++ b/artifex-client-cli/src/tls/file_signing_key.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-use anyhow::{Context, Result};
 use rsa::{
     pkcs1::EncodeRsaPublicKey,
     pkcs1v15,
@@ -16,12 +15,22 @@ use rsa::{
     RsaPrivateKey,
 };
 use std::path::Path;
+use thiserror::Error;
 use tokio_rustls::rustls::{
     self,
     pki_types::SubjectPublicKeyInfoDer,
     sign::{Signer, SigningKey},
     SignatureAlgorithm, SignatureScheme,
 };
+
+/// Errors occuring when handling a file-based signing key.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("PKCS8 error: {0}")]
+    Pkcs8(#[from] pkcs8::Error),
+}
 
 /// Perform signature with private key.
 #[derive(Clone, Debug)]
@@ -78,13 +87,8 @@ pub(super) struct FileSigningKeyBuilder {
 
 impl FileSigningKeyBuilder {
     /// Create a new file signing key builder.
-    pub(super) fn with_pem_file<P: AsRef<Path>>(key_path: P) -> Result<Self> {
-        let key_pem = std::fs::read_to_string(&key_path).with_context(|| {
-            format!(
-                "Failed to read private key from {}",
-                key_path.as_ref().display()
-            )
-        })?;
+    pub(super) fn with_pem_file<P: AsRef<Path>>(key_path: P) -> Result<Self, Error> {
+        let key_pem = std::fs::read_to_string(&key_path)?;
         Ok(Self {
             key_pem,
             password: None,
@@ -96,13 +100,13 @@ impl FileSigningKeyBuilder {
         self
     }
     /// Build a file signing key.
-    pub(super) fn build(self) -> Result<FileSigningKey> {
+    pub(super) fn build(self) -> Result<FileSigningKey, Error> {
         let inner = if let Some(password) = &self.password {
             RsaPrivateKey::from_pkcs8_encrypted_pem(&self.key_pem, password)
         } else {
             RsaPrivateKey::from_pkcs8_pem(&self.key_pem)
         };
-        let inner = inner.with_context(|| "Failed to create RSA key")?;
+        let inner = inner?;
         Ok(FileSigningKey { inner })
     }
 }

--- a/artifex-client-cli/src/tls/file_signing_key.rs
+++ b/artifex-client-cli/src/tls/file_signing_key.rs
@@ -25,12 +25,12 @@ use tokio_rustls::rustls::{
 
 /// Perform signature with private key.
 #[derive(Clone, Debug)]
-struct ClientSigner {
+struct InternalSigner {
     key: RsaPrivateKey,
     scheme: SignatureScheme,
 }
 
-impl Signer for ClientSigner {
+impl Signer for InternalSigner {
     fn scheme(&self) -> SignatureScheme {
         self.scheme
     }
@@ -69,15 +69,15 @@ impl Signer for ClientSigner {
     }
 }
 
-// A builder for configuring a client signing key.
+// A builder for configuring a file signing key.
 #[derive(Debug)]
-pub(super) struct ClientSigningKeyBuilder {
+pub(super) struct FileSigningKeyBuilder {
     key_pem: String,
     password: Option<String>,
 }
 
-impl ClientSigningKeyBuilder {
-    /// Create a new client signing key builder.
+impl FileSigningKeyBuilder {
+    /// Create a new file signing key builder.
     pub(super) fn with_pem_file<P: AsRef<Path>>(key_path: P) -> Result<Self> {
         let key_pem = std::fs::read_to_string(&key_path).with_context(|| {
             format!(
@@ -95,25 +95,25 @@ impl ClientSigningKeyBuilder {
         self.password = Some(password.to_string());
         self
     }
-    /// Build a client signing key.
-    pub(super) fn build(self) -> Result<ClientSigningKey> {
+    /// Build a file signing key.
+    pub(super) fn build(self) -> Result<FileSigningKey> {
         let inner = if let Some(password) = &self.password {
             RsaPrivateKey::from_pkcs8_encrypted_pem(&self.key_pem, password)
         } else {
             RsaPrivateKey::from_pkcs8_pem(&self.key_pem)
         };
         let inner = inner.with_context(|| "Failed to create RSA key")?;
-        Ok(ClientSigningKey { inner })
+        Ok(FileSigningKey { inner })
     }
 }
 
 /// Represent a private signing key.
 #[derive(Clone, Debug)]
-pub(super) struct ClientSigningKey {
+pub(super) struct FileSigningKey {
     inner: RsaPrivateKey,
 }
 
-impl ClientSigningKey {
+impl FileSigningKey {
     /// Return the list of supported signature schemes.
     fn supported_schemes(&self) -> &[SignatureScheme] {
         match self.inner.to_public_key().size() {
@@ -134,7 +134,7 @@ impl ClientSigningKey {
     }
 }
 
-impl SigningKey for ClientSigningKey {
+impl SigningKey for FileSigningKey {
     fn algorithm(&self) -> SignatureAlgorithm {
         SignatureAlgorithm::RSA
     }
@@ -143,7 +143,7 @@ impl SigningKey for ClientSigningKey {
         let supported = self.supported_schemes();
         for scheme in offered {
             if supported.contains(scheme) {
-                return Some(Box::new(ClientSigner {
+                return Some(Box::new(InternalSigner {
                     key: self.inner.clone(),
                     scheme: *scheme,
                 }));


### PR DESCRIPTION
This PR refactors TLS support in `artifex-client-cli` by:

- rebranding `ClientSigningKey` to `FileSigningKey`.
- using custom error types.
- removing `impl Default` for `tls::Config`

This allows reusing the functions to create a TLS-capable client in other projects.

