### PR TITLE
client-cli: pass certs and keys as URIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "tonic",
  "tonic-reflection",
  "tower",
+ "url",
 ]
 
 [[package]]
@@ -572,6 +573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +628,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs_extra"
@@ -958,6 +979,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1194,12 @@ name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -1374,6 +1508,15 @@ dependencies = [
  "pkcs5",
  "rand_core 0.6.4",
  "spki",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -1910,6 +2053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,6 +2086,17 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tempfile"
@@ -1999,6 +2159,16 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -2295,6 +2465,23 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -2609,6 +2796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "xshell"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,6 +2821,30 @@ name = "xtask"
 version = "0.1.1"
 dependencies = [
  "xshell",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -2651,7 +2868,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/artifex-client-cli/Cargo.toml
+++ b/artifex-client-cli/Cargo.toml
@@ -28,3 +28,4 @@ toml = "0.8.22"
 tonic = { version = "0.13.0", features = ["tls-ring"] }
 tonic-reflection = "0.13.0"
 tower = "0.5.2"
+url = "2.5.4"

--- a/artifex-client-cli/data/example/config.toml
+++ b/artifex-client-cli/data/example/config.toml
@@ -1,6 +1,6 @@
 format = "Yaml"
 url = "https://127.0.0.1:50051"
 [tls]
-root_cert = "./tests/data/tls/root.crt.pem"
-client_cert = "./tests/data/tls/client.crt.pem"
-client_key = "./tests/data/tls/client.key.pem"
+root_cert = "data:tests/data/tls/root.crt.pem"
+client_cert = "data:tests/data/tls/client.crt.pem"
+client_key = "data:tests/data/tls/client.key.pem"

--- a/artifex-client-cli/src/config.rs
+++ b/artifex-client-cli/src/config.rs
@@ -8,7 +8,7 @@ use super::password::PasswordProvider;
 use super::tls::Config as TlsConfig;
 use artifex_batch::MarkupKind;
 use serde::Deserialize;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use thiserror::Error;
 
 /// Errors reported when managing the configuration.
@@ -41,9 +41,9 @@ impl Default for Config {
             url: Self::DEFAULT_URL.to_string(),
             password_provider: PasswordProvider::Prompt,
             tls: TlsConfig {
-                root_cert: PathBuf::from(Self::DEFAULT_TLS_ROOT_CERT),
-                client_cert: PathBuf::from(Self::DEFAULT_TLS_CLIENT_CERT),
-                client_key: PathBuf::from(Self::DEFAULT_TLS_CLIENT_KEY),
+                root_cert: Self::DEFAULT_TLS_ROOT_CERT.to_string(),
+                client_cert: Self::DEFAULT_TLS_CLIENT_CERT.to_string(),
+                client_key: Self::DEFAULT_TLS_CLIENT_KEY.to_string(),
                 client_password: None,
                 server_alt_name: None,
             },
@@ -55,11 +55,11 @@ impl Config {
     /// Default URL to connect to.
     pub const DEFAULT_URL: &str = "https://127.0.0.1:50051";
     /// Default TLS root certification authority file.
-    pub const DEFAULT_TLS_ROOT_CERT: &str = "/etc/artifex/root.crt.pem";
+    pub const DEFAULT_TLS_ROOT_CERT: &str = "file:/etc/artifex/root.crt.pem";
     /// Default TLS client certificate.
-    pub const DEFAULT_TLS_CLIENT_CERT: &str = "/etc/artifex/client.crt.pem";
+    pub const DEFAULT_TLS_CLIENT_CERT: &str = "file:/etc/artifex/client.crt.pem";
     /// Default TLS client private key.
-    pub const DEFAULT_TLS_CLIENT_KEY: &str = "/etc/artifex/client.key.pem";
+    pub const DEFAULT_TLS_CLIENT_KEY: &str = "file:/etc/artifex/client.key.pem";
     /// Create a new configuration from file at `path`.
     pub fn with_path<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
         let text = std::fs::read_to_string(path)?;

--- a/artifex-client-cli/src/main.rs
+++ b/artifex-client-cli/src/main.rs
@@ -70,24 +70,14 @@ struct Cli {
     #[arg(
         short = 'r',
         long,
-        help = "Root certificate authority file",
-        value_name = "FILE"
+        help = "Root certificate authority URI",
+        value_name = "URI"
     )]
-    pub root_cert: Option<PathBuf>,
-    #[arg(
-        short = 'c',
-        long,
-        help = "Client certificate file",
-        value_name = "FILE"
-    )]
-    pub client_cert: Option<PathBuf>,
-    #[arg(
-        short = 'k',
-        long,
-        help = "Client private key file",
-        value_name = "FILE"
-    )]
-    pub client_key: Option<PathBuf>,
+    pub root_cert: Option<String>,
+    #[arg(short = 'c', long, help = "Client certificate URI", value_name = "URI")]
+    pub client_cert: Option<String>,
+    #[arg(short = 'k', long, help = "Client private key URI", value_name = "URI")]
+    pub client_key: Option<String>,
     #[arg(
         short = 'n',
         long,

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -6,23 +6,23 @@
 
 //! TLS client configuration.
 
+mod cert;
 mod client_cert_resolver;
 mod file_signing_key;
+mod uri;
 
 use serde::Deserialize;
-use std::{path::PathBuf, sync::Arc};
+use std::sync::Arc;
 use thiserror::Error;
-use tokio_rustls::rustls::{
-    self,
-    pki_types::{self, pem::PemObject, CertificateDer},
-    ClientConfig, RootCertStore,
-};
+use tokio_rustls::rustls::{self, pki_types, ClientConfig, RootCertStore};
 
 use client_cert_resolver::ClientCertResolverBuilder;
 
 /// Errors occuring when configuring TLS connection.
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("Certificate error: {0}")]
+    Certificate(#[from] cert::Error),
     #[error("Client certificate resolver error: {0}")]
     ClientCertResolver(#[from] client_cert_resolver::Error),
     #[error("I/O error: {0}")]
@@ -36,13 +36,13 @@ pub enum Error {
 /// Hold the configuration of the TLS.
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct Config {
-    /// Path to root certification authority file.
-    pub root_cert: PathBuf,
-    /// Path to client certificate file.
-    pub client_cert: PathBuf,
-    /// Path to client private key file.
-    pub client_key: PathBuf,
-    /// Password for client private key file.
+    /// URI for root certification authority.
+    pub root_cert: String,
+    /// URI for client certificate.
+    pub client_cert: String,
+    /// URI for client private key.
+    pub client_key: String,
+    /// Password for client private key.
     pub client_password: Option<String>,
     /// Server alternative name.
     pub server_alt_name: Option<String>,
@@ -51,11 +51,11 @@ pub struct Config {
 /// Create TLS client configuration.
 pub fn create_client_config(config: &Config) -> Result<ClientConfig, Error> {
     let mut ca_store = RootCertStore::empty();
-    let root_cert = CertificateDer::from_pem_file(&config.root_cert)?;
+    let root_cert = cert::load_certificate(&config.root_cert)?;
     ca_store.add(root_cert)?;
     let provider = rustls::crypto::ring::default_provider();
     let mut client_cert_resolver_builder =
-        ClientCertResolverBuilder::with_pem_files(&config.client_cert, &config.client_key)?;
+        ClientCertResolverBuilder::new(&config.client_cert, &config.client_key)?;
     if let Some(password) = &config.client_password {
         client_cert_resolver_builder.password(password);
     }

--- a/artifex-client-cli/src/tls/cert.rs
+++ b/artifex-client-cli/src/tls/cert.rs
@@ -1,0 +1,29 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! Certificate management.
+
+use super::uri::{self, Uri};
+use thiserror::Error;
+use tokio_rustls::rustls::pki_types::{pem::PemObject, CertificateDer};
+
+/// Errors reported when hendling a X509 certificate.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("URI error: {0}")]
+    Uri(#[from] uri::Error),
+    #[error("PEM error: {0}")]
+    Pem(#[from] tokio_rustls::rustls::pki_types::pem::Error),
+}
+
+pub(crate) fn load_certificate<'a>(uri: &str) -> Result<CertificateDer<'a>, Error> {
+    let uri = Uri::parse(uri).map_err(uri::Error::InvalidUri)?;
+    let cert = match uri.scheme() {
+        "file" | "data" => CertificateDer::from_pem_file(&uri.path())?,
+        s => return Err(Error::Uri(uri::Error::UnsupportedScheme(s.to_string()))),
+    };
+    Ok(cert)
+}

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -4,43 +4,45 @@
 // SPDX-License-Identifier: MIT
 //
 
-use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
-use tokio_rustls::rustls::{
-    client::ResolvesClientCert,
-    pki_types::{self, pem::PemObject, CertificateDer},
-    sign::CertifiedKey,
-    SignatureScheme,
-};
+use tokio_rustls::rustls::{client::ResolvesClientCert, sign::CertifiedKey, SignatureScheme};
 
 use crate::tls::file_signing_key::FileSigningKeyBuilder;
+
+use super::cert;
+use super::uri::{self, Uri};
 
 /// Errors occuring when operating with a client certificate resolver.
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("Certificate error: {0}")]
+    Certificate(#[from] cert::Error),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("PEM error: {0}")]
-    Pem(#[from] pki_types::pem::Error),
     #[error("Signing key error: {0}")]
     SigningKey(#[from] crate::tls::file_signing_key::Error),
+    #[error("URI error: {0}")]
+    Uri(#[from] crate::tls::uri::Error),
 }
 
 // A builder for configuring a client client certificate resolver.
 #[derive(Debug)]
 pub(super) struct ClientCertResolverBuilder {
-    cert_pem: String,
+    cert_uri: String,
     key_builder: FileSigningKeyBuilder,
 }
 
 impl ClientCertResolverBuilder {
     /// Create a builder.
-    pub(super) fn with_pem_files<P: AsRef<Path>>(cert_path: P, key_path: P) -> Result<Self, Error> {
-        let cert_pem = std::fs::read_to_string(&cert_path)?;
-        let key_builder = FileSigningKeyBuilder::with_pem_file(&key_path)?;
+    pub(super) fn new(cert_uri: &str, key_uri: &str) -> Result<Self, Error> {
+        let key_uri = Uri::parse(key_uri).map_err(uri::Error::InvalidUri)?;
+        let key_builder = match key_uri.scheme() {
+            "file" | "data" => FileSigningKeyBuilder::with_pem_file(&key_uri.path())?,
+            s => return Err(Error::Uri(uri::Error::UnsupportedScheme(s.to_string()))),
+        };
         Ok(Self {
-            cert_pem,
+            cert_uri: cert_uri.to_string(),
             key_builder,
         })
     }
@@ -51,7 +53,7 @@ impl ClientCertResolverBuilder {
     }
     /// Build a client certificate resolver.
     pub(super) fn build(self) -> Result<ClientCertResolver, Error> {
-        let cert = CertificateDer::from_pem_reader(self.cert_pem.as_bytes())?;
+        let cert = cert::load_certificate(&self.cert_uri)?;
         let key = self.key_builder.build()?;
         let key = CertifiedKey::new(vec![cert], Arc::new(key));
         Ok(ClientCertResolver { key: Arc::new(key) })

--- a/artifex-client-cli/src/tls/uri.rs
+++ b/artifex-client-cli/src/tls/uri.rs
@@ -1,0 +1,20 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! URI management.
+
+use thiserror::Error;
+
+/// Errors reported when hendling an URI.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Invalid URI: {0}")]
+    InvalidUri(#[from] url::ParseError),
+    #[error("Unsupported scheme: {0}")]
+    UnsupportedScheme(String),
+}
+
+pub use url::Url as Uri;


### PR DESCRIPTION
In order to prepare support for certificates and keys stored on PKCS#11 tokens, pass certs and keys as URIs, not file paths.

Hence certificates and keys stored in files should now be passed as URIs with "file" scheme (e.g. "file:/path/to/root.crt.pem").

Paths used in URIs with "file" scheme must be absolute. For relative paths, use "data" scheme.