### PR TITLE
client-cli: pass client key password source via URI

### DIFF
--- a/artifex-client-cli/data/example/config.toml
+++ b/artifex-client-cli/data/example/config.toml
@@ -3,4 +3,4 @@ url = "https://127.0.0.1:50051"
 [tls]
 root_cert = "data:tests/data/tls/root.crt.pem"
 client_cert = "data:tests/data/tls/client.crt.pem"
-client_key = "data:tests/data/tls/client.key.pem"
+client_key = "data:tests/data/tls/client.key.pem?password-source=env:CLIENT_KEY_PASSWORD"

--- a/artifex-client-cli/src/config.rs
+++ b/artifex-client-cli/src/config.rs
@@ -44,7 +44,6 @@ impl Default for Config {
                 root_cert: Self::DEFAULT_TLS_ROOT_CERT.to_string(),
                 client_cert: Self::DEFAULT_TLS_CLIENT_CERT.to_string(),
                 client_key: Self::DEFAULT_TLS_CLIENT_KEY.to_string(),
-                client_password: None,
                 server_alt_name: None,
             },
         }

--- a/artifex-client-cli/src/main.rs
+++ b/artifex-client-cli/src/main.rs
@@ -6,9 +6,7 @@
 
 use anyhow::{Context, Result};
 use artifex_batch::{Batch, BatchRunner, MarkupKind, MarkupReportRenderer};
-use artifex_client_cli::{
-    client::ClientBuilder, config::Config, password::PasswordProvider, tls::Config as TlsConfig,
-};
+use artifex_client_cli::{client::ClientBuilder, config::Config, tls::Config as TlsConfig};
 use clap::{Parser, ValueEnum};
 use std::{
     fs::File,
@@ -58,13 +56,6 @@ struct Cli {
         default_value = Config::DEFAULT_URL
     )]
     url: Option<String>,
-    #[arg(
-        short = 'S',
-        long = "password",
-        help = "Password provider",
-        value_name = "PROVIDER"
-    )]
-    password_provider: Option<PasswordProvider>,
     #[arg(short = 'R', long, help = "Path to report file", value_name = "FILE")]
     report: Option<PathBuf>,
     #[arg(
@@ -116,17 +107,11 @@ async fn main() -> Result<()> {
     let input = args.batch().with_context(|| "failed to open input")?;
     let mut output = args.report().with_context(|| "failed to create report")?;
     let url = args.url.unwrap_or(config.url);
-    let password_provider = args.password_provider.unwrap_or(config.password_provider);
     let builder = if let Some(("https", _)) = url.split_once("://") {
-        let password = password_provider
-            .provide()
-            .map(|s| if s.trim().is_empty() { None } else { Some(s) })
-            .with_context(|| "Failed to get password")?;
         let tls = TlsConfig {
             root_cert: args.root_cert.unwrap_or(config.tls.root_cert),
             client_cert: args.client_cert.unwrap_or(config.tls.client_cert),
             client_key: args.client_key.unwrap_or(config.tls.client_key),
-            client_password: password,
             server_alt_name: args.server_alt_name.or(config.tls.server_alt_name),
         };
         ClientBuilder::with_tls_config(tls)

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -46,8 +46,6 @@ pub struct Config {
     pub client_cert: String,
     /// URI for client private key.
     pub client_key: String,
-    /// Password for client private key.
-    pub client_password: Option<String>,
     /// Server alternative name.
     pub server_alt_name: Option<String>,
 }

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -9,7 +9,6 @@
 mod cert;
 mod client_cert_resolver;
 mod file;
-mod file_signing_key;
 mod uri;
 
 use serde::Deserialize;

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -8,6 +8,7 @@
 
 mod cert;
 mod client_cert_resolver;
+mod file;
 mod file_signing_key;
 mod uri;
 
@@ -17,6 +18,7 @@ use thiserror::Error;
 use tokio_rustls::rustls::{self, pki_types, ClientConfig, RootCertStore};
 
 use client_cert_resolver::ClientCertResolverBuilder;
+use uri::Uri;
 
 /// Errors occuring when configuring TLS connection.
 #[derive(Debug, Error)]
@@ -31,6 +33,8 @@ pub enum Error {
     Pem(#[from] pki_types::pem::Error),
     #[error("RusTLS error: {0}")]
     RusTls(#[from] rustls::Error),
+    #[error("URI error: {0}")]
+    Uri(#[from] uri::Error),
 }
 
 /// Hold the configuration of the TLS.
@@ -51,7 +55,8 @@ pub struct Config {
 /// Create TLS client configuration.
 pub fn create_client_config(config: &Config) -> Result<ClientConfig, Error> {
     let mut ca_store = RootCertStore::empty();
-    let root_cert = cert::load_certificate(&config.root_cert)?;
+    let root_cert_uri = config.root_cert.parse::<Uri>()?;
+    let root_cert = cert::load_certificate(&root_cert_uri)?;
     ca_store.add(root_cert)?;
     let provider = rustls::crypto::ring::default_provider();
     let mut client_cert_resolver_builder =

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio_rustls::rustls::{self, pki_types, ClientConfig, RootCertStore};
 
-use client_cert_resolver::ClientCertResolverBuilder;
+use client_cert_resolver::ClientCertResolver;
 use uri::Uri;
 
 /// Errors occuring when configuring TLS connection.
@@ -58,13 +58,11 @@ pub fn create_client_config(config: &Config) -> Result<ClientConfig, Error> {
     let root_cert_uri = config.root_cert.parse::<Uri>()?;
     let root_cert = cert::load_certificate(&root_cert_uri)?;
     ca_store.add(root_cert)?;
+    let client_cert_uri = config.client_cert.parse::<Uri>()?;
+    let client_key_uri = config.client_key.parse::<Uri>()?;
+    let client_key_uri = client_key_uri.source_secret()?;
+    let client_cert_resolver = ClientCertResolver::new(&client_cert_uri, &client_key_uri)?;
     let provider = rustls::crypto::ring::default_provider();
-    let mut client_cert_resolver_builder =
-        ClientCertResolverBuilder::new(&config.client_cert, &config.client_key)?;
-    if let Some(password) = &config.client_password {
-        client_cert_resolver_builder.password(password);
-    }
-    let client_cert_resolver = client_cert_resolver_builder.build()?;
     let tls = ClientConfig::builder_with_provider(provider.into())
         .with_safe_default_protocol_versions()?;
     let tls = tls

--- a/artifex-client-cli/src/tls/cert.rs
+++ b/artifex-client-cli/src/tls/cert.rs
@@ -19,11 +19,8 @@ pub enum Error {
     Pem(#[from] tokio_rustls::rustls::pki_types::pem::Error),
 }
 
-pub(crate) fn load_certificate<'a>(uri: &str) -> Result<CertificateDer<'a>, Error> {
-    let uri = Uri::parse(uri).map_err(uri::Error::InvalidUri)?;
-    let cert = match uri.scheme() {
-        "file" | "data" => CertificateDer::from_pem_file(&uri.path())?,
-        s => return Err(Error::Uri(uri::Error::UnsupportedScheme(s.to_string()))),
-    };
+pub(crate) fn load_certificate<'a>(uri: &Uri) -> Result<CertificateDer<'a>, Error> {
+    let Uri::File(uri) = uri;
+    let cert = CertificateDer::from_pem_file(&uri.path())?;
     Ok(cert)
 }

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 use tokio_rustls::rustls::{client::ResolvesClientCert, sign::CertifiedKey, SignatureScheme};
 
 use super::cert;
-use super::file::signing_key::FileSigningKeyBuilder;
+use super::file::signing_key::FileSigningKey;
 use super::uri::Uri;
 
 /// Errors occuring when operating with a client certificate resolver.
@@ -36,11 +36,7 @@ impl ClientCertResolver {
     pub(super) fn new(cert_uri: &Uri, key_uri: &Uri) -> Result<Self, Error> {
         let cert = cert::load_certificate(&cert_uri)?;
         let Uri::File(key_uri) = key_uri;
-        let mut key_builder = FileSigningKeyBuilder::with_pem_file(&key_uri.path())?;
-        if let Some(password) = key_uri.password() {
-            key_builder.password(password);
-        }
-        let key = key_builder.build()?;
+        let key = FileSigningKey::new(&key_uri)?;
         let key = CertifiedKey::new(vec![cert], Arc::new(key));
         Ok(ClientCertResolver { key: Arc::new(key) })
     }

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -26,42 +26,25 @@ pub enum Error {
     Uri(#[from] crate::tls::uri::Error),
 }
 
-// A builder for configuring a client client certificate resolver.
-#[derive(Debug)]
-pub(super) struct ClientCertResolverBuilder {
-    cert_uri: Uri,
-    key_builder: FileSigningKeyBuilder,
-}
-
-impl ClientCertResolverBuilder {
-    /// Create a builder.
-    pub(super) fn new(cert_uri: &str, key_uri: &str) -> Result<Self, Error> {
-        let cert_uri = cert_uri.parse::<Uri>()?;
-        let Uri::File(key_uri) = key_uri.parse::<Uri>()?;
-        let key_builder = FileSigningKeyBuilder::with_pem_file(&key_uri.path())?;
-        Ok(Self {
-            cert_uri,
-            key_builder,
-        })
-    }
-    /// Set password for key decryption.
-    pub(super) fn password(&mut self, password: &str) -> &Self {
-        self.key_builder.password(password);
-        self
-    }
-    /// Build a client certificate resolver.
-    pub(super) fn build(self) -> Result<ClientCertResolver, Error> {
-        let cert = cert::load_certificate(&self.cert_uri)?;
-        let key = self.key_builder.build()?;
-        let key = CertifiedKey::new(vec![cert], Arc::new(key));
-        Ok(ClientCertResolver { key: Arc::new(key) })
-    }
-}
-
 /// Choose the certificate chain and private key for client authentication.
 #[derive(Debug)]
 pub(super) struct ClientCertResolver {
     key: Arc<CertifiedKey>,
+}
+
+impl ClientCertResolver {
+    /// Create a new client certificate resolver.
+    pub(super) fn new(cert_uri: &Uri, key_uri: &Uri) -> Result<Self, Error> {
+        let cert = cert::load_certificate(&cert_uri)?;
+        let Uri::File(key_uri) = key_uri;
+        let mut key_builder = FileSigningKeyBuilder::with_pem_file(&key_uri.path())?;
+        if let Some(password) = key_uri.password() {
+            key_builder.password(password);
+        }
+        let key = key_builder.build()?;
+        let key = CertifiedKey::new(vec![cert], Arc::new(key));
+        Ok(ClientCertResolver { key: Arc::new(key) })
+    }
 }
 
 impl ResolvesClientCert for ClientCertResolver {

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -11,7 +11,7 @@ use tokio_rustls::rustls::{client::ResolvesClientCert, sign::CertifiedKey, Signa
 use crate::tls::file_signing_key::FileSigningKeyBuilder;
 
 use super::cert;
-use super::uri::{self, Uri};
+use super::uri::Uri;
 
 /// Errors occuring when operating with a client certificate resolver.
 #[derive(Debug, Error)]
@@ -29,20 +29,18 @@ pub enum Error {
 // A builder for configuring a client client certificate resolver.
 #[derive(Debug)]
 pub(super) struct ClientCertResolverBuilder {
-    cert_uri: String,
+    cert_uri: Uri,
     key_builder: FileSigningKeyBuilder,
 }
 
 impl ClientCertResolverBuilder {
     /// Create a builder.
     pub(super) fn new(cert_uri: &str, key_uri: &str) -> Result<Self, Error> {
-        let key_uri = Uri::parse(key_uri).map_err(uri::Error::InvalidUri)?;
-        let key_builder = match key_uri.scheme() {
-            "file" | "data" => FileSigningKeyBuilder::with_pem_file(&key_uri.path())?,
-            s => return Err(Error::Uri(uri::Error::UnsupportedScheme(s.to_string()))),
-        };
+        let cert_uri = cert_uri.parse::<Uri>()?;
+        let Uri::File(key_uri) = key_uri.parse::<Uri>()?;
+        let key_builder = FileSigningKeyBuilder::with_pem_file(&key_uri.path())?;
         Ok(Self {
-            cert_uri: cert_uri.to_string(),
+            cert_uri,
             key_builder,
         })
     }

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -8,9 +8,8 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio_rustls::rustls::{client::ResolvesClientCert, sign::CertifiedKey, SignatureScheme};
 
-use crate::tls::file_signing_key::FileSigningKeyBuilder;
-
 use super::cert;
+use super::file::signing_key::FileSigningKeyBuilder;
 use super::uri::Uri;
 
 /// Errors occuring when operating with a client certificate resolver.
@@ -21,7 +20,7 @@ pub enum Error {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
     #[error("Signing key error: {0}")]
-    SigningKey(#[from] crate::tls::file_signing_key::Error),
+    SigningKey(#[from] crate::tls::file::signing_key::Error),
     #[error("URI error: {0}")]
     Uri(#[from] crate::tls::uri::Error),
 }

--- a/artifex-client-cli/src/tls/file.rs
+++ b/artifex-client-cli/src/tls/file.rs
@@ -1,0 +1,9 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+mod uri;
+
+pub use uri::FileUri;

--- a/artifex-client-cli/src/tls/file.rs
+++ b/artifex-client-cli/src/tls/file.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+pub(crate) mod signing_key;
 mod uri;
 
 pub use uri::FileUri;

--- a/artifex-client-cli/src/tls/file/signing_key.rs
+++ b/artifex-client-cli/src/tls/file/signing_key.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+use super::FileUri;
 use rsa::{
     pkcs1::EncodeRsaPublicKey,
     pkcs1v15,
@@ -14,7 +15,6 @@ use rsa::{
     traits::PublicKeyParts,
     RsaPrivateKey,
 };
-use std::path::Path;
 use thiserror::Error;
 use tokio_rustls::rustls::{
     self,
@@ -78,39 +78,6 @@ impl Signer for InternalSigner {
     }
 }
 
-// A builder for configuring a file signing key.
-#[derive(Debug)]
-pub(crate) struct FileSigningKeyBuilder {
-    key_pem: String,
-    password: Option<String>,
-}
-
-impl FileSigningKeyBuilder {
-    /// Create a new file signing key builder.
-    pub(crate) fn with_pem_file<P: AsRef<Path>>(key_path: P) -> Result<Self, Error> {
-        let key_pem = std::fs::read_to_string(&key_path)?;
-        Ok(Self {
-            key_pem,
-            password: None,
-        })
-    }
-    /// Set password for key decryption.
-    pub(crate) fn password(&mut self, password: &str) -> &Self {
-        self.password = Some(password.to_string());
-        self
-    }
-    /// Build a file signing key.
-    pub(crate) fn build(self) -> Result<FileSigningKey, Error> {
-        let inner = if let Some(password) = &self.password {
-            RsaPrivateKey::from_pkcs8_encrypted_pem(&self.key_pem, password)
-        } else {
-            RsaPrivateKey::from_pkcs8_pem(&self.key_pem)
-        };
-        let inner = inner?;
-        Ok(FileSigningKey { inner })
-    }
-}
-
 /// Represent a private signing key.
 #[derive(Clone, Debug)]
 pub(crate) struct FileSigningKey {
@@ -118,6 +85,17 @@ pub(crate) struct FileSigningKey {
 }
 
 impl FileSigningKey {
+    /// Create a new file-based signing key.
+    pub(crate) fn new(uri: &FileUri) -> Result<Self, Error> {
+        let pem_data = std::fs::read_to_string(&uri.path())?;
+        let inner = if let Some(password) = uri.password() {
+            RsaPrivateKey::from_pkcs8_encrypted_pem(&pem_data, password)
+        } else {
+            RsaPrivateKey::from_pkcs8_pem(&pem_data)
+        };
+        let inner = inner?;
+        Ok(FileSigningKey { inner })
+    }
     /// Return the list of supported signature schemes.
     fn supported_schemes(&self) -> &[SignatureScheme] {
         match self.inner.to_public_key().size() {

--- a/artifex-client-cli/src/tls/file/signing_key.rs
+++ b/artifex-client-cli/src/tls/file/signing_key.rs
@@ -80,14 +80,14 @@ impl Signer for InternalSigner {
 
 // A builder for configuring a file signing key.
 #[derive(Debug)]
-pub(super) struct FileSigningKeyBuilder {
+pub(crate) struct FileSigningKeyBuilder {
     key_pem: String,
     password: Option<String>,
 }
 
 impl FileSigningKeyBuilder {
     /// Create a new file signing key builder.
-    pub(super) fn with_pem_file<P: AsRef<Path>>(key_path: P) -> Result<Self, Error> {
+    pub(crate) fn with_pem_file<P: AsRef<Path>>(key_path: P) -> Result<Self, Error> {
         let key_pem = std::fs::read_to_string(&key_path)?;
         Ok(Self {
             key_pem,
@@ -95,12 +95,12 @@ impl FileSigningKeyBuilder {
         })
     }
     /// Set password for key decryption.
-    pub(super) fn password(&mut self, password: &str) -> &Self {
+    pub(crate) fn password(&mut self, password: &str) -> &Self {
         self.password = Some(password.to_string());
         self
     }
     /// Build a file signing key.
-    pub(super) fn build(self) -> Result<FileSigningKey, Error> {
+    pub(crate) fn build(self) -> Result<FileSigningKey, Error> {
         let inner = if let Some(password) = &self.password {
             RsaPrivateKey::from_pkcs8_encrypted_pem(&self.key_pem, password)
         } else {
@@ -113,7 +113,7 @@ impl FileSigningKeyBuilder {
 
 /// Represent a private signing key.
 #[derive(Clone, Debug)]
-pub(super) struct FileSigningKey {
+pub(crate) struct FileSigningKey {
     inner: RsaPrivateKey,
 }
 

--- a/artifex-client-cli/src/tls/file/uri.rs
+++ b/artifex-client-cli/src/tls/file/uri.rs
@@ -1,0 +1,91 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! Refer to cryptograhic items in files via URI.
+
+use crate::tls::uri::Error;
+use std::path::{Path, PathBuf};
+use url::Url;
+
+/// Represent the URI identifying a cryptographic object stored in a file.
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileUri {
+    pub(crate) path: PathBuf,
+    pub(crate) password: Option<String>,
+    pub(crate) password_source: Option<String>,
+}
+
+impl FileUri {
+    /// Return the path of the cryptographic object.
+    pub fn path(&self) -> &Path {
+        self.path.as_ref()
+    }
+    /// Return the password for accessing the cryptographic object.
+    pub fn password(&self) -> Option<&str> {
+        self.password.as_deref()
+    }
+    /// Return the source of the password for accessing the cryptographic object.
+    pub fn password_source(&self) -> Option<&str> {
+        self.password_source.as_deref()
+    }
+}
+
+impl TryFrom<&Url> for FileUri {
+    type Error = Error;
+
+    fn try_from(url: &Url) -> std::result::Result<Self, Self::Error> {
+        if url.scheme() != "file" && url.scheme() != "data" {
+            return Err(Error::InvalidUri("Invalid scheme".to_string()));
+        }
+        let path = PathBuf::from(url.path());
+        let mut password = None;
+        let mut password_source = None;
+        let pairs = url.query_pairs();
+        for (k, v) in pairs {
+            match k.as_ref() {
+                "password" => password = Some(v.into()),
+                "password-source" => password_source = Some(v.into()),
+                _ => {}
+            }
+        }
+        Ok(Self {
+            path,
+            password,
+            password_source,
+        })
+    }
+}
+
+impl std::str::FromStr for FileUri {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uri = Url::parse(s)?;
+        let uri = FileUri::try_from(&uri)?;
+        Ok(uri)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_URI: &str = "file:/some/where/client.key.pem?password-source=env:SOME_SECRET";
+
+    #[test]
+    fn try_from_valid() {
+        let url = Url::parse(VALID_URI).unwrap();
+        let res = FileUri::try_from(&url);
+        let reference = FileUri {
+            path: PathBuf::from("/some/where/client.key.pem"),
+            password: None,
+            password_source: Some("env:SOME_SECRET".to_string()),
+        };
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), reference);
+    }
+}

--- a/artifex-client-cli/src/tls/uri.rs
+++ b/artifex-client-cli/src/tls/uri.rs
@@ -6,15 +6,64 @@
 
 //! URI management.
 
-use thiserror::Error;
+use crate::password::PasswordProvider;
 
-/// Errors reported when hendling an URI.
+use super::file::FileUri;
+use thiserror::Error;
+use url::Url;
+
+/// Errors reported when handling an URI.
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("Invalid URI: {0}")]
-    InvalidUri(#[from] url::ParseError),
+    InvalidUri(String),
+    #[error("Password provider error: {0}")]
+    PasswordProvider(#[from] crate::password::Error),
     #[error("Unsupported scheme: {0}")]
     UnsupportedScheme(String),
+    #[error("URL error: {0}")]
+    Url(#[from] url::ParseError),
 }
 
-pub use url::Url as Uri;
+/// Represent the URI identifying a cryptographic object.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Uri {
+    File(FileUri),
+}
+
+impl std::str::FromStr for Uri {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uri = Url::parse(s)?;
+        let uri = match uri.scheme() {
+            "file" | "data" => {
+                let uri = FileUri::try_from(&uri)?;
+                Uri::File(uri)
+            }
+            s => return Err(Error::UnsupportedScheme(s.to_string())),
+        };
+        Ok(uri)
+    }
+}
+
+impl Uri {
+    /// Check if URI contains a secret-sourcing member
+    /// and if so return a URI where the secret member
+    /// has been sourced.
+    /// If the URI already contains a secret, it is left untouched.
+    pub fn source_secret(self) -> Result<Uri, Error> {
+        let Uri::File(uri) = self;
+        if uri.password().is_none() {
+            let password = if let Some(source) = uri.password_source() {
+                let provider = source.parse::<PasswordProvider>()?;
+                let password = provider.provide()?;
+                Some(password)
+            } else {
+                None
+            };
+            Ok(Uri::File(FileUri { password, ..uri }))
+        } else {
+            Ok(Uri::File(uri))
+        }
+    }
+}


### PR DESCRIPTION
This PR heavily reworks URI handling in `artifex-client-cli`  to allow passing the source of the password of the encrypted client key via the `?password-source` URI query parameter (not unlike `?pin-source` in RFC7512 for PKCKS#11 URI).

Client key URI examples:

  - `file:///some/where/client.key.pem?password-source=env:CLIENT_KEY_PASSWORD`
  - `file:///some/where/client.key.pem?password-source=fd:3`
  - `file:///some/where/client.key.pem?password-source=file:/some/where/client.key.password.txt`

This entails the removal of the `--password` option in `artifex-client-cli` CLI tool.

Usage example:

```sh
export CLIENT_KEY_PASSWORD=$(cat tests/data/tls/client.key.password.txt) 
artifex-client-cli -C artifex-client-cli/data/example/config.toml
```