### PR TITLE
client-cli: add support for PKCS#11-based TLS certificate and key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,7 @@ dependencies = [
  "artifex-batch",
  "artifex-rpc",
  "clap",
+ "cryptoki",
  "futures",
  "hyper",
  "hyper-rustls",
@@ -318,7 +319,7 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -334,6 +335,12 @@ dependencies = [
  "syn",
  "which",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -450,7 +457,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.7",
 ]
 
 [[package]]
@@ -547,6 +554,29 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cryptoki"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b34e469ac5a28d546ed7aae9dd69037b38f4e966cd9adb2a01250a5d257de02"
+dependencies = [
+ "bitflags 1.3.2",
+ "cryptoki-sys",
+ "libloading 0.7.4",
+ "log",
+ "paste",
+ "secrecy",
+]
+
+[[package]]
+name = "cryptoki-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d279ad423469b93e631f4bc53f277c7424cf01353c70eba685046d294dc042c7"
+dependencies = [
+ "libloading 0.7.4",
 ]
 
 [[package]]
@@ -1169,6 +1199,16 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
@@ -1282,7 +1322,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1404,6 +1444,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pbkdf2"
@@ -1686,7 +1732,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -1807,7 +1853,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1820,7 +1866,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -1915,12 +1961,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2792,7 +2847,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]

--- a/artifex-client-cli/Cargo.toml
+++ b/artifex-client-cli/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.75"
 artifex-batch = { path = "../artifex-batch" }
 artifex-rpc = { path = "../artifex-rpc" }
 clap = { version = "4.4.8", features = ["derive"] }
+cryptoki = "0.9.0"
 futures = "0.3.29"
 hyper = "1.6.0"
 hyper-rustls = { version = "0.27.5", features = ["http2", "ring"] }

--- a/artifex-client-cli/data/example/config_pkcs11.toml
+++ b/artifex-client-cli/data/example/config_pkcs11.toml
@@ -1,0 +1,6 @@
+format = "Yaml"
+url = "https://127.0.0.1:50051"
+[tls]
+root_cert = "pkcs11:token=Artifex%20Client%20Token%2001;object=Artifex%20Root%20CA%20Certificate%2001?module-path=/usr/lib64/libsofthsm2.so"
+client_cert = "pkcs11:token=Artifex%20Client%20Token%2001;object=Artifex%20Client%20Certificate%2001?module-path=/usr/lib64/libsofthsm2.so"
+client_key = "pkcs11:token=Artifex%20Client%20Token%2001;object=Artifex%20Client%20Key%2001?module-path=/usr/lib64/libsofthsm2.so&pin-source=env:CLIENT_KEY_PASSWORD"

--- a/artifex-client-cli/src/tls.rs
+++ b/artifex-client-cli/src/tls.rs
@@ -9,6 +9,7 @@
 mod cert;
 mod client_cert_resolver;
 mod file;
+mod pkcs11;
 mod uri;
 
 use serde::Deserialize;

--- a/artifex-client-cli/src/tls/cert.rs
+++ b/artifex-client-cli/src/tls/cert.rs
@@ -6,13 +6,18 @@
 
 //! Certificate management.
 
-use super::uri::{self, Uri};
+use super::{
+    pkcs11,
+    uri::{self, Uri},
+};
 use thiserror::Error;
 use tokio_rustls::rustls::pki_types::{pem::PemObject, CertificateDer};
 
 /// Errors reported when hendling a X509 certificate.
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("PKCS#11 error: {0}")]
+    Pkcs11(#[from] pkcs11::Error),
     #[error("URI error: {0}")]
     Uri(#[from] uri::Error),
     #[error("PEM error: {0}")]
@@ -20,7 +25,11 @@ pub enum Error {
 }
 
 pub(crate) fn load_certificate<'a>(uri: &Uri) -> Result<CertificateDer<'a>, Error> {
-    let Uri::File(uri) = uri;
-    let cert = CertificateDer::from_pem_file(&uri.path())?;
+    let cert = match uri {
+        Uri::File(uri) => CertificateDer::from_pem_file(&uri.path())?,
+        Uri::Pkcs11(uri) => pkcs11::read_certificate(uri)
+            .map_err(pkcs11::Error::Certificate)
+            .map(CertificateDer::from)?,
+    };
     Ok(cert)
 }

--- a/artifex-client-cli/src/tls/client_cert_resolver.rs
+++ b/artifex-client-cli/src/tls/client_cert_resolver.rs
@@ -10,6 +10,7 @@ use tokio_rustls::rustls::{client::ResolvesClientCert, sign::CertifiedKey, Signa
 
 use super::cert;
 use super::file::signing_key::FileSigningKey;
+use super::pkcs11::signing_key::Pkcs11SigningKey;
 use super::uri::Uri;
 
 /// Errors occuring when operating with a client certificate resolver.
@@ -17,10 +18,12 @@ use super::uri::Uri;
 pub enum Error {
     #[error("Certificate error: {0}")]
     Certificate(#[from] cert::Error),
+    #[error("File signing key error: {0}")]
+    FileSigningKey(#[from] crate::tls::file::signing_key::Error),
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
-    #[error("Signing key error: {0}")]
-    SigningKey(#[from] crate::tls::file::signing_key::Error),
+    #[error("PKCS#11 signing key error: {0}")]
+    Pkcs11SigningKey(#[from] crate::tls::pkcs11::signing_key::Error),
     #[error("URI error: {0}")]
     Uri(#[from] crate::tls::uri::Error),
 }
@@ -35,9 +38,16 @@ impl ClientCertResolver {
     /// Create a new client certificate resolver.
     pub(super) fn new(cert_uri: &Uri, key_uri: &Uri) -> Result<Self, Error> {
         let cert = cert::load_certificate(&cert_uri)?;
-        let Uri::File(key_uri) = key_uri;
-        let key = FileSigningKey::new(&key_uri)?;
-        let key = CertifiedKey::new(vec![cert], Arc::new(key));
+        let key = match key_uri {
+            Uri::File(uri) => {
+                let key = FileSigningKey::new(uri)?;
+                CertifiedKey::new(vec![cert], Arc::new(key))
+            }
+            Uri::Pkcs11(uri) => {
+                let key = Pkcs11SigningKey::new(uri)?;
+                CertifiedKey::new(vec![cert], Arc::new(key))
+            }
+        };
         Ok(ClientCertResolver { key: Arc::new(key) })
     }
 }

--- a/artifex-client-cli/src/tls/pkcs11.rs
+++ b/artifex-client-cli/src/tls/pkcs11.rs
@@ -1,0 +1,23 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! Manage certificates and keys on PKCS#11 cryptographic tokens.
+
+mod cert;
+pub(crate) mod signing_key;
+mod uri;
+
+use thiserror::Error;
+
+/// Errors reported when handling PKCS#11 items.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Certificate error: {0}")]
+    Certificate(#[from] cert::Error),
+}
+
+pub use cert::read_certificate;
+pub use uri::Pkcs11Uri;

--- a/artifex-client-cli/src/tls/pkcs11/cert.rs
+++ b/artifex-client-cli/src/tls/pkcs11/cert.rs
@@ -1,0 +1,58 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! Manage certificates on PKCS#11 cryptographic tokens.
+
+use crate::tls::pkcs11::Pkcs11Uri;
+use cryptoki::{
+    context::{CInitializeArgs, Pkcs11},
+    object::{Attribute, AttributeType, CertificateType},
+};
+use thiserror::Error;
+
+/// Errors reported when handling certificates on PKCS#11 tokens.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Cryptoki error: {0}")]
+    Cryptoki(#[from] cryptoki::error::Error),
+    #[error("Invalid data: {0}")]
+    InvalidData(String),
+    #[error("Not found: {0}")]
+    NotFound(String),
+}
+
+/// Return the certificate matching a given URI.
+pub fn read_certificate(uri: &Pkcs11Uri) -> Result<Vec<u8>, Error> {
+    let pkcs11 = Pkcs11::new(uri.module_path())?;
+    pkcs11.initialize(CInitializeArgs::OsThreads)?;
+    let slots = pkcs11.get_slots_with_initialized_token()?;
+    if slots.is_empty() {
+        return Err(Error::NotFound("No PKCS#11 token found".to_string()));
+    }
+    let session = pkcs11.open_ro_session(slots[0])?;
+    let cert_template = [
+        Attribute::Label(uri.object().as_bytes().to_vec()),
+        Attribute::CertificateType(CertificateType::X_509),
+        Attribute::Token(true),
+    ];
+    let certs = session.find_objects(&cert_template)?;
+    if certs.is_empty() {
+        return Err(Error::NotFound("No such PKCS#11 certificate".to_string()));
+    }
+    let attrs = session.get_attributes(certs[0], &[AttributeType::Value])?;
+    if attrs.is_empty() {
+        return Err(Error::InvalidData(
+            "PKCS#11 object has no value".to_string(),
+        ));
+    }
+    if let Attribute::Value(value) = &attrs[0] {
+        Ok(value.to_owned())
+    } else {
+        Err(Error::InvalidData(
+            "PKCS#11 object attribute is not a value".to_string(),
+        ))
+    }
+}

--- a/artifex-client-cli/src/tls/pkcs11/signing_key.rs
+++ b/artifex-client-cli/src/tls/pkcs11/signing_key.rs
@@ -1,0 +1,196 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use super::Pkcs11Uri;
+use cryptoki::{
+    context::{CInitializeArgs, Pkcs11},
+    mechanism::{
+        rsa::{PkcsMgfType, PkcsPssParams},
+        Mechanism, MechanismType,
+    },
+    object::{Attribute, AttributeType, KeyType, ObjectHandle},
+    session::{Session, UserType},
+    types::AuthPin,
+};
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+use tokio_rustls::rustls::{
+    self,
+    pki_types::SubjectPublicKeyInfoDer,
+    sign::{Signer, SigningKey},
+    SignatureAlgorithm, SignatureScheme,
+};
+
+/// Errors occuring when handling a PKCS#11-based signing key.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Cryptoki error: {0}")]
+    Cryptoki(#[from] cryptoki::error::Error),
+    #[error("Invalid data: {0}")]
+    InvalidData(String),
+    #[error("Missing PIN")]
+    MissingPin,
+    #[error("Not found: {0}")]
+    NotFound(String),
+}
+
+/// Perform signature with private key.
+#[derive(Clone, Debug)]
+struct Pkcs11Signer {
+    context: Pkcs11SigningContext,
+    scheme: SignatureScheme,
+}
+
+impl Pkcs11Signer {
+    /// Return the mechanism matching the scheme.
+    fn mechanism(&self) -> Result<Mechanism, rustls::Error> {
+        match self.scheme {
+            SignatureScheme::RSA_PKCS1_SHA256 => Ok(Mechanism::Sha256RsaPkcs),
+            SignatureScheme::RSA_PKCS1_SHA384 => Ok(Mechanism::Sha384RsaPkcs),
+            SignatureScheme::RSA_PKCS1_SHA512 => Ok(Mechanism::Sha512RsaPkcs),
+            SignatureScheme::RSA_PSS_SHA256 => {
+                let params = PkcsPssParams {
+                    hash_alg: MechanismType::SHA256,
+                    mgf: PkcsMgfType::MGF1_SHA256,
+                    s_len: 32.into(),
+                };
+                Ok(Mechanism::Sha256RsaPkcsPss(params))
+            }
+            SignatureScheme::RSA_PSS_SHA384 => {
+                let params = PkcsPssParams {
+                    hash_alg: MechanismType::SHA384,
+                    mgf: PkcsMgfType::MGF1_SHA384,
+                    s_len: 48.into(),
+                };
+                Ok(Mechanism::Sha384RsaPkcsPss(params))
+            }
+            SignatureScheme::RSA_PSS_SHA512 => {
+                let params = PkcsPssParams {
+                    hash_alg: MechanismType::SHA512,
+                    mgf: PkcsMgfType::MGF1_SHA512,
+                    s_len: 64.into(),
+                };
+                Ok(Mechanism::Sha512RsaPkcsPss(params))
+            }
+            _ => Err(rustls::Error::General(
+                "Unsupported signature scheme".to_string(),
+            )),
+        }
+    }
+}
+
+impl Signer for Pkcs11Signer {
+    fn scheme(&self) -> SignatureScheme {
+        self.scheme
+    }
+
+    fn sign(&self, message: &[u8]) -> Result<Vec<u8>, rustls::Error> {
+        let mechanism = self.mechanism()?;
+        let session = self.context.session.lock().unwrap();
+        let data = session
+            .sign(&mechanism, self.context.key, message)
+            .map_err(|e| rustls::Error::General(format!("Failed to sign: {e}")))?;
+        Ok(data)
+    }
+}
+
+/// Hold everything to sign.
+#[derive(Clone, Debug)]
+struct Pkcs11SigningContext {
+    session: Arc<Mutex<Session>>,
+    key: ObjectHandle,
+}
+
+/// Represent a private signing key, in a PKCS#11 token.
+#[derive(Clone, Debug)]
+pub(crate) struct Pkcs11SigningKey {
+    #[allow(dead_code)]
+    pkcs11: Pkcs11,
+    context: Pkcs11SigningContext,
+}
+
+impl Pkcs11SigningKey {
+    /// Create a new PKCS#11-based signing key.
+    pub(crate) fn new(uri: &Pkcs11Uri) -> Result<Self, Error> {
+        let pkcs11 = Pkcs11::new(uri.module_path())?;
+        pkcs11.initialize(CInitializeArgs::OsThreads)?;
+        let session = Self::open_session(&pkcs11, uri)?;
+        let key_template = vec![
+            Attribute::Label(uri.object().as_bytes().to_vec()),
+            Attribute::Private(true),
+            Attribute::Sign(true),
+            Attribute::KeyType(KeyType::RSA),
+        ];
+        let keys = session.find_objects(&key_template)?;
+        if keys.is_empty() {
+            return Err(Error::NotFound("No such PKCS#11 key".to_string()));
+        }
+        Ok(Self {
+            pkcs11,
+            context: Pkcs11SigningContext {
+                session: Arc::new(Mutex::new(session)),
+                key: keys[0],
+            },
+        })
+    }
+    /// Open session.
+    fn open_session(pkcs11: &Pkcs11, uri: &Pkcs11Uri) -> Result<Session, Error> {
+        let slots = pkcs11.get_slots_with_initialized_token()?;
+        if slots.is_empty() {
+            return Err(Error::NotFound("No PKCS#11 token found".to_string()));
+        }
+        let pin = uri.pin().ok_or_else(|| Error::MissingPin)?;
+        let pin = AuthPin::new(pin.into());
+        let session = pkcs11.open_ro_session(slots[0])?;
+        session.login(UserType::User, Some(&pin))?;
+        Ok(session)
+    }
+    /// Return the list of supported signature schemes.
+    fn supported_schemes(&self) -> &[SignatureScheme] {
+        &[
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+        ]
+    }
+}
+
+impl SigningKey for Pkcs11SigningKey {
+    fn algorithm(&self) -> SignatureAlgorithm {
+        SignatureAlgorithm::RSA
+    }
+
+    fn choose_scheme(&self, offered: &[SignatureScheme]) -> Option<Box<dyn Signer>> {
+        let supported = self.supported_schemes();
+        for scheme in offered {
+            if supported.contains(scheme) {
+                return Some(Box::new(Pkcs11Signer {
+                    context: self.context.clone(),
+                    scheme: *scheme,
+                }));
+            }
+        }
+        None
+    }
+
+    fn public_key(&self) -> Option<SubjectPublicKeyInfoDer<'_>> {
+        let session = self.context.session.lock().unwrap();
+        session
+            .get_attributes(self.context.key, &[AttributeType::PublicKeyInfo])
+            .ok()
+            .and_then(|attrs| attrs.into_iter().next())
+            .and_then(|attr| {
+                if let Attribute::PublicKeyInfo(value) = attr {
+                    Some(value.into())
+                } else {
+                    None
+                }
+            })
+    }
+}

--- a/artifex-client-cli/src/tls/pkcs11/uri.rs
+++ b/artifex-client-cli/src/tls/pkcs11/uri.rs
@@ -1,0 +1,140 @@
+//
+// Copyright (C) 2022-2025 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! Refer to cryptographic items on PKCS#11 cryptographic tokens via URI.
+
+use crate::tls::uri::Error;
+use std::collections::HashMap;
+use std::str::FromStr;
+use url::Url;
+
+#[derive(Debug)]
+struct Pkcs11Params(HashMap<String, String>);
+
+impl FromStr for Pkcs11Params {
+    type Err = Error;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        let items = s.split(';');
+        let result: std::result::Result<HashMap<String, String>, Self::Err> = items
+            .map(|kv| {
+                kv.find('=')
+                    .ok_or(Error::InvalidUri("Malformed parameter".to_string()))
+                    .map(move |p| (kv[0..p].to_string(), kv[p + 1..].replace("%20", " ")))
+            })
+            .collect();
+        Ok(Pkcs11Params(result?))
+    }
+}
+
+impl TryFrom<&Url> for Pkcs11Params {
+    type Error = Error;
+
+    fn try_from(url: &Url) -> std::result::Result<Self, Self::Error> {
+        let params = url.path().parse::<Pkcs11Params>()?;
+        Ok(params)
+    }
+}
+
+/// Represent the URI identifying a PKCS#11 object stored on a PKCS#11 token.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pkcs11Uri {
+    pub(crate) module_path: String,
+    pub(crate) token: String,
+    pub(crate) object: String,
+    pub(crate) pin: Option<String>,
+    pub(crate) pin_source: Option<String>,
+}
+
+impl Pkcs11Uri {
+    /// Return the absolute path to the PKCS#11 module to use.
+    pub fn module_path(&self) -> &str {
+        &self.module_path
+    }
+    /// Return the name of the PKCS#11 token to use.
+    #[allow(dead_code)]
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+    /// Return the name of the PKCS#11 object to use.
+    pub fn object(&self) -> &str {
+        &self.object
+    }
+    /// Return the PIN of the PKCS#11 object to use.
+    pub fn pin(&self) -> Option<&str> {
+        self.pin.as_deref()
+    }
+    /// Return the PIN source of the PKCS#11 object to use.
+    pub fn pin_source(&self) -> Option<&str> {
+        self.pin_source.as_deref()
+    }
+}
+
+impl TryFrom<&Url> for Pkcs11Uri {
+    type Error = Error;
+
+    fn try_from(url: &Url) -> std::result::Result<Self, Self::Error> {
+        let mut params = Pkcs11Params::try_from(url)?;
+        let mut module_path = None;
+        let mut pin = None;
+        let mut pin_source = None;
+        let pairs = url.query_pairs();
+        for (k, v) in pairs {
+            match k.as_ref() {
+                "module-path" => module_path = Some(v.into()),
+                "pin-value" => pin = Some(v.into()),
+                "pin-source" => pin_source = Some(v.into()),
+                _ => {}
+            }
+        }
+        Ok(Pkcs11Uri {
+            module_path: module_path
+                .ok_or_else(|| Error::InvalidUri("Missing module-path".to_string()))?,
+            token: params
+                .0
+                .remove("token")
+                .ok_or_else(|| Error::InvalidUri("Missing token".to_string()))?,
+            object: params
+                .0
+                .remove("object")
+                .ok_or_else(|| Error::InvalidUri("Missing object".to_string()))?,
+            pin,
+            pin_source,
+        })
+    }
+}
+
+impl FromStr for Pkcs11Uri {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let uri = Url::parse(s)?;
+        let uri = Pkcs11Uri::try_from(&uri)?;
+        Ok(uri)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID_URI: &str =
+        "pkcs11:token=Artifex%20Client%20Token%2002;object=Artifex%20Client%20Key%2002?module-path=/usr/lib64/libsofthsm2.so&pin-source=env:CLIENT_KEY_PASSWORD";
+
+    #[test]
+    fn try_from_valid() {
+        let url = Url::parse(VALID_URI).unwrap();
+        let res = Pkcs11Uri::try_from(&url);
+        let reference = Pkcs11Uri {
+            module_path: "/usr/lib64/libsofthsm2.so".to_string(),
+            token: "Artifex Client Token 02".to_string(),
+            object: "Artifex Client Key 02".to_string(),
+            pin: None,
+            pin_source: Some("env:CLIENT_KEY_PASSWORD".to_string()),
+        };
+        assert!(res.is_ok());
+        assert_eq!(res.unwrap(), reference);
+    }
+}

--- a/artifex-client-cli/src/tls/uri.rs
+++ b/artifex-client-cli/src/tls/uri.rs
@@ -9,6 +9,7 @@
 use crate::password::PasswordProvider;
 
 use super::file::FileUri;
+use super::pkcs11::Pkcs11Uri;
 use thiserror::Error;
 use url::Url;
 
@@ -19,6 +20,8 @@ pub enum Error {
     InvalidUri(String),
     #[error("Password provider error: {0}")]
     PasswordProvider(#[from] crate::password::Error),
+    #[error("PKCS#11 error {0}")]
+    Pkcs11(#[from] super::pkcs11::Error),
     #[error("Unsupported scheme: {0}")]
     UnsupportedScheme(String),
     #[error("URL error: {0}")]
@@ -29,6 +32,7 @@ pub enum Error {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Uri {
     File(FileUri),
+    Pkcs11(Pkcs11Uri),
 }
 
 impl std::str::FromStr for Uri {
@@ -39,6 +43,10 @@ impl std::str::FromStr for Uri {
             "file" | "data" => {
                 let uri = FileUri::try_from(&uri)?;
                 Uri::File(uri)
+            }
+            "pkcs11" => {
+                let uri = Pkcs11Uri::try_from(&uri)?;
+                Uri::Pkcs11(uri)
             }
             s => return Err(Error::UnsupportedScheme(s.to_string())),
         };
@@ -52,18 +60,35 @@ impl Uri {
     /// has been sourced.
     /// If the URI already contains a secret, it is left untouched.
     pub fn source_secret(self) -> Result<Uri, Error> {
-        let Uri::File(uri) = self;
-        if uri.password().is_none() {
-            let password = if let Some(source) = uri.password_source() {
-                let provider = source.parse::<PasswordProvider>()?;
-                let password = provider.provide()?;
-                Some(password)
-            } else {
-                None
-            };
-            Ok(Uri::File(FileUri { password, ..uri }))
-        } else {
-            Ok(Uri::File(uri))
+        match self {
+            Uri::File(uri) => {
+                if uri.password().is_none() {
+                    let password = if let Some(source) = uri.password_source() {
+                        let provider = source.parse::<PasswordProvider>()?;
+                        let password = provider.provide()?;
+                        Some(password)
+                    } else {
+                        None
+                    };
+                    Ok(Uri::File(FileUri { password, ..uri }))
+                } else {
+                    Ok(Uri::File(uri))
+                }
+            }
+            Uri::Pkcs11(uri) => {
+                if uri.pin().is_none() {
+                    let pin = if let Some(source) = uri.pin_source() {
+                        let provider = source.parse::<PasswordProvider>()?;
+                        let pin = provider.provide()?;
+                        Some(pin)
+                    } else {
+                        None
+                    };
+                    Ok(Uri::Pkcs11(Pkcs11Uri { pin, ..uri }))
+                } else {
+                    Ok(Uri::Pkcs11(uri))
+                }
+            }
         }
     }
 }

--- a/tests/data/tls/README.md
+++ b/tests/data/tls/README.md
@@ -110,3 +110,191 @@ Verify that the client certificate is signed by root CA:
 ```sh
 openssl verify -CAfile root.crt.pem client.crt.pem
 ```
+
+## PKCS#11-based credentials
+
+[PKCS11][PKCS11] is the standard to interact with cryptographic tokens.
+
+[SoftHSM][SOFTHSM] is an implementation of a cryptographic store accessible
+through a PKCS #11 interface. You can use it to explore PKCS #11 without having
+a Hardware Security Module.
+
+#### Installation
+
+On Fedora GNU/Linux systems, [SoftHSM][SOFTHSM] can be installed as follows:
+
+```sh
+sudo dnf install -y softhsm p11-kit openssl
+```
+
+The user should configure the location of the virtual tokens:
+
+```sh
+mkdir -p ~/softhsm/tokens
+mkdir -p ~/.config/softhsm2
+echo "directories.tokendir = $HOME/softhsm/tokens" > ~/.config/softhsm2/softhsm2.conf
+```
+
+#### Token creation
+
+To create a token named "Artifex Client Token 01" with "0000" as PIN for Security
+Officer and "53cr3tP4ssw0rd" as PIN for the user, execute:
+
+```sh
+softhsm2-util --init-token --free \
+              --label "Artifex Client Token 01" \
+              --so-pin "0000" \
+              --pin "53cr3tP4ssw0rd"
+```
+
+The output of the command should look like:
+
+```
+Slot 0 has a free/uninitialized token.
+The token has been initialized and is reassigned to slot 1295994237
+```
+
+The [p11-kit][P11KIT] project provides tools to interact with PKCS#11 tokens.
+Among them, `p11tool` can be used to check the presence of the newly created token:
+
+```sh
+p11tool --list-token-urls | grep SoftHSM
+```
+
+The output of the command should look like:
+
+```
+pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=54dc4636118a5a86;token=Artifex%20Client%20Token%2001
+```
+
+#### Import client private key
+
+To import the RSA private key for the client named
+``tests/data/tls/client.key.pem`` in the token as "Artifex Client Key 01",
+execute:
+
+```sh
+p11tool --login --set-pin '53cr3tP4ssw0rd' \
+        --load-privkey=tests/data/tls/client.key.pem \
+        --label 'Artifex Client Key 01' \
+        --mark-sign \
+        --mark-decrypt \
+        --write \
+        pkcs11:token=Artifex%20Client%20Token%2001
+```
+
+To check the key has been properly imported, execute:
+
+```sh
+p11tool --login --set-pin '53cr3tP4ssw0rd' \
+        --list-privkeys \
+        pkcs11:token=Artifex%20Client%20Token%2001
+```
+
+The output of the command should look like:
+
+```
+Object 0:
+        URL: pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=146839644d3f4d7d;token=Artifex%20Client%20Token%2001;id=%56%95%F0%8E%EA%07%51%FD%6D%ED%81%E6%3D%93%D6%82%C3%66%30%77;object=Artifex%20Client%20Key%2001;type=private
+        Type: Private key (RSA-4096)
+        Label: Artifex Client Key 01
+        Flags: CKA_WRAP/UNWRAP; CKA_PRIVATE; CKA_SENSITIVE;
+        ID: 56:95:f0:8e:ea:07:51:fd:6d:ed:81:e6:3d:93:d6:82:c3:66:30:77
+```
+
+To test signature, execute:
+
+```sh
+p11tool --login --set-pin '53cr3tP4ssw0rd' \
+        --test-sign \
+        --hash=SHA512 \
+        'pkcs11:token=Artifex%20Client%20Token%2001;object=Artifex%20Client%20Key%2001'
+```
+
+#### Import client certificate
+
+To import the certificate for the client named ``tests/data/tls/client.crt.pem``
+in the token as "Artifex Client Certificate 01", execute:
+
+```sh
+p11tool --login --set-pin '53cr3tP4ssw0rd' \
+        --load-certificate=tests/data/tls/client.crt.pem \
+        --label 'Artifex Client Certificate 01' \
+        --write \
+        pkcs11:token=Artifex%20Client%20Token%2001
+```
+
+The output must look like this:
+
+```
+note: will reuse ID 5695f08eea0751fd6ded81e63d93d682c3663077 from corresponding private key
+```
+
+To check the certificate has been properly imported, execute:
+
+```sh
+p11tool --login --set-pin '53cr3tP4ssw0rd' \
+        --list-certs \
+        pkcs11:token=Artifex%20Client%20Token%2001
+```
+
+The output of the command should look like:
+
+```
+Object 0:
+        URL: pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=146839644d3f4d7d;token=Artifex%20Client%20Token%2001;id=%56%95%F0%8E%EA%07%51%FD%6D%ED%81%E6%3D%93%D6%82%C3%66%30%77;object=Artifex%20Client%20Certificate%2001;type=cert
+        Type: X.509 Certificate (RSA-4096)
+        Expires: Mon Feb 19 10:29:16 2035
+        Label: Artifex Client Certificate 01
+        ID: 56:95:f0:8e:ea:07:51:fd:6d:ed:81:e6:3d:93:d6:82:c3:66:30:77
+```
+
+It is possible to read the certificate by executing:
+
+```sh
+p11tool --export \
+        "pkcs11:token=Artifex%20Client%20Token%2001;object=Artifex%20Client%20Certificate%2001"
+```
+
+#### Import root CA certificate
+
+The same procedure as above can be used to import the root CA certificate.
+
+```sh
+p11tool --login --set-pin '53cr3tP4ssw0rd' \
+        --load-certificate=tests/data/tls/root.crt.pem \
+        --label 'Artifex Root CA Certificate 01' \
+        --mark-ca \
+        --write \
+        pkcs11:token=Artifex%20Client%20Token%2001
+```
+
+To list the certificates, execute:
+
+```sh
+p11tool --login --set-pin '53cr3tP4ssw0rd' \
+        --list-certs \
+        pkcs11:token=Artifex%20Client%20Token%2001
+```
+
+The output should now be:
+
+```
+Object 0:
+        URL: pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=146839644d3f4d7d;token=Artifex%20Client%20Token%2001;id=%56%95%F0%8E%EA%07%51%FD%6D%ED%81%E6%3D%93%D6%82%C3%66%30%77;object=Artifex%20Client%20Certificate%2001;type=cert
+        Type: X.509 Certificate (RSA-4096)
+        Expires: Mon Feb 19 10:29:16 2035
+        Label: Artifex Client Certificate 01
+        ID: 56:95:f0:8e:ea:07:51:fd:6d:ed:81:e6:3d:93:d6:82:c3:66:30:77
+
+Object 1:
+        URL: pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=146839644d3f4d7d;token=Artifex%20Client%20Token%2001;id=%61%6F%DE%6A%34%72%65%02%90%67%30%15%DE%05%5E%B8%E5%5B%BF%70;object=Artifex%20Root%20CA%20Certificate%2001;type=cert
+        Type: X.509 Certificate (RSA-4096)
+        Expires: Thu May  3 16:30:38 2035
+        Label: Artifex Root CA Certificate 01
+        ID: 61:6f:de:6a:34:72:65:02:90:67:30:15:de:05:5e:b8:e5:5b:bf:70
+```
+
+[SOFTHSM]: https://www.opendnssec.org/softhsm/
+[P11KIT]: https://p11-glue.github.io/p11-glue/p11-kit.html
+[PKCS11]: https://en.wikipedia.org/wiki/PKCS_11

--- a/tests/data/tls/README.md
+++ b/tests/data/tls/README.md
@@ -3,7 +3,8 @@
 Here are the commands to generate the keys and certificates required for running
 an Artifex server and a client with a TLS connection.
 
-## Root Certification Authority
+## File-based credentials
+### Root Certification Authority
 
 Create a private key, then a self-signed certificate:
 
@@ -23,7 +24,7 @@ openssl x509 -req -in root.csr.pem -out root.crt.pem \
         -extfile root.cnf
 ```
 
-## Server
+### Server
 
 Create a private key, then a certificate, signed by the root CA:
 
@@ -73,7 +74,7 @@ Verify that the server certificate is signed by root CA:
 openssl verify -CAfile root.crt.pem server.crt.pem
 ```
 
-## Client
+### Client
 
 Create password file for client private key:
 


### PR DESCRIPTION
This PR adds support for setting up a TLS connection with `artifex-client-cli` using certificates and keys stored in a PKCS#11 token.

 The URL of the certificate or the private key is formatted as required by [RFC7512](https://www.rfc-editor.org/rfc/rfc7512).

Tests can be run using [SoftHSM](https://www.softhsm.org/).

See `artifex-client-cli/data/example/config_pkcs11.toml` for a configuration example.

