### PR TITLE
Add file upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -88,6 +88,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "artifex-batch"
 version = "0.1.1"
 dependencies = [
@@ -125,7 +137,7 @@ dependencies = [
  "anyhow",
  "artifex-rpc",
  "cryptoki",
- "futures",
+ "futures 0.3.32",
  "hyper",
  "hyper-rustls",
  "hyper-util",
@@ -161,7 +173,12 @@ dependencies = [
 name = "artifex-rpc"
 version = "0.1.1"
 dependencies = [
+ "blake3",
+ "futures 0.3.32",
  "prost",
+ "tokio",
+ "tokio-fs",
+ "tokio-stream",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -174,8 +191,10 @@ dependencies = [
  "anyhow",
  "artifex-engine",
  "artifex-rpc",
+ "blake3",
  "clap",
- "futures",
+ "futures 0.3.32",
+ "hex",
  "serde",
  "thiserror",
  "tokio",
@@ -240,7 +259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "bytes",
+ "bytes 1.11.1",
  "futures-util",
  "http",
  "http-body",
@@ -264,7 +283,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "futures-core",
  "http",
  "http-body",
@@ -295,6 +314,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.4",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +350,22 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -344,6 +393,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -442,6 +497,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,6 +525,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20ff29ded3204c5106278a81a38f4b482636ed4fa1e6cfbeef193291beb29ed"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "crossbeam-utils",
+ "lazy_static",
+ "maybe-uninit",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if 0.1.10",
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -607,6 +725,12 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
+
+[[package]]
+name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
@@ -709,7 +833,7 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "wasi",
 ]
@@ -720,7 +844,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
@@ -732,7 +856,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
@@ -748,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
- "bytes",
+ "bytes 1.11.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -782,6 +906,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,7 +932,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "itoa",
 ]
 
@@ -806,7 +942,7 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "http",
 ]
 
@@ -816,7 +952,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "futures-core",
  "http",
  "http-body",
@@ -848,7 +984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
- "bytes",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-core",
  "h2",
@@ -899,7 +1035,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "futures-channel",
  "futures-util",
  "http",
@@ -1069,6 +1205,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,7 +1250,7 @@ version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
  "wasm-bindgen",
@@ -1138,7 +1283,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "windows-link",
 ]
 
@@ -1191,10 +1336,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1226,7 +1386,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
 ]
@@ -1287,6 +1447,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,7 +1490,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -1470,7 +1640,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "prost-derive",
 ]
 
@@ -1669,7 +1839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.4",
  "getrandom 0.2.17",
  "libc",
  "untrusted",
@@ -1917,8 +2087,8 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
- "cpufeatures",
+ "cfg-if 1.0.4",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2080,7 +2250,7 @@ version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
 ]
 
 [[package]]
@@ -2095,11 +2265,11 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "libc",
  "mio",
  "parking_lot",
@@ -2108,6 +2278,38 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-executor"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
+dependencies = [
+ "crossbeam-utils",
+ "futures 0.1.31",
+]
+
+[[package]]
+name = "tokio-fs"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
+dependencies = [
+ "futures 0.1.31",
+ "tokio-io",
+ "tokio-threadpool",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
+dependencies = [
+ "bytes 0.4.12",
+ "futures 0.1.31",
+ "log",
 ]
 
 [[package]]
@@ -2143,12 +2345,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-threadpool"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df720b6581784c118f0eb4310796b12b1d242a7eb95f716a8367855325c25f89"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-queue",
+ "crossbeam-utils",
+ "futures 0.1.31",
+ "lazy_static",
+ "log",
+ "num_cpus",
+ "slab",
+ "tokio-executor",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -2205,7 +2424,7 @@ dependencies = [
  "async-trait",
  "axum",
  "base64",
- "bytes",
+ "bytes 1.11.1",
  "h2",
  "http",
  "http-body",
@@ -2244,7 +2463,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
- "bytes",
+ "bytes 1.11.1",
  "prost",
  "tonic",
 ]
@@ -2286,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6a1b6319ca4b61a4c0f0c94d439c8f3ed344cca56fe0df40e1fe4be11380b"
 dependencies = [
  "base64",
- "bytes",
+ "bytes 1.11.1",
  "http",
  "http-body",
  "pin-project",
@@ -2521,7 +2740,7 @@ version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,8 @@ dependencies = [
  "humantime",
  "serde",
  "thiserror",
+ "tokio",
+ "tokio-stream",
  "tonic",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,5 @@ futures = "0.3.29"
 serde = { version = "1.0.219", features = ["derive"] }
 thiserror = "2.0.12"
 tokio = { version = "1.52", features = ["full"] }
+tokio-stream = "0.1.18"
 toml = "0.8.22"

--- a/artifex-batch/Cargo.toml
+++ b/artifex-batch/Cargo.toml
@@ -18,10 +18,14 @@ thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
+tokio = { version = "1.52", default-features = false, features = ["rt"] }
+tokio-stream = "0.1"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tonic = "0.14"
+tokio = { version = "1.52", features = ["full"] }
+tokio-stream = "0.1"
 
 [lints]
 workspace = true

--- a/artifex-batch/Cargo.toml
+++ b/artifex-batch/Cargo.toml
@@ -19,13 +19,13 @@ thiserror = { workspace = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 tokio = { version = "1.52", default-features = false, features = ["rt"] }
-tokio-stream = "0.1"
+tokio-stream = { workspace = true }
 getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tonic = "0.14"
 tokio = { version = "1.52", features = ["full"] }
-tokio-stream = "0.1"
+tokio-stream = { workspace = true }
 
 [lints]
 workspace = true

--- a/artifex-batch/src/command.rs
+++ b/artifex-batch/src/command.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-use std::{fmt::Display, str::FromStr};
+use std::{fmt::Display, path::PathBuf, str::FromStr};
 use thiserror::Error;
 
 /// Errors raised when handling a `Command`.
@@ -24,6 +24,7 @@ pub enum Command {
     Execute(String),
     Inspect,
     Upgrade,
+    Upload(PathBuf),
 }
 
 impl FromStr for Command {
@@ -35,9 +36,10 @@ impl FromStr for Command {
         }
         match s.split_once(':') {
             Some(("EXECUTE", arg)) => Ok(Command::Execute(arg.trim().to_string())),
+            Some(("UPLOAD", arg)) => Ok(Command::Upload(arg.trim().into())),
             Some((cmd, _)) => Err(Error::UnknownCommand(cmd.to_string())),
             None => match s {
-                "EXECUTE" => Err(Error::MissingArgument),
+                "EXECUTE" | "UPLOAD" => Err(Error::MissingArgument),
                 "INSPECT" => Ok(Command::Inspect),
                 "UPGRADE" => Ok(Command::Upgrade),
                 _ => Err(Error::UnknownCommand(s.to_string())),
@@ -52,6 +54,7 @@ impl Display for Command {
             Command::Execute(command) => write!(f, "EXECUTE: {command}"),
             Command::Inspect => write!(f, "INSPECT"),
             Command::Upgrade => write!(f, "UPGRADE"),
+            Command::Upload(path) => write!(f, "UPLOAD: {}", path.display()),
         }
     }
 }

--- a/artifex-batch/src/lib.rs
+++ b/artifex-batch/src/lib.rs
@@ -9,8 +9,10 @@ mod command;
 mod error;
 mod report;
 mod runner;
+mod upload_progress;
 
 pub use batch::Batch;
 pub use error::Error;
 pub use report::{BatchReport, MarkupKind, MarkupReportRenderer};
 pub use runner::BatchRunner;
+pub use upload_progress::UploadProgress;

--- a/artifex-batch/src/runner.rs
+++ b/artifex-batch/src/runner.rs
@@ -11,7 +11,10 @@ use crate::{
     report::{BatchReport, ReportEntry},
 };
 
-use artifex_rpc::{ExecuteRequest, InspectRequest, UpgradeRequest, artifex_client::ArtifexClient};
+use artifex_rpc::{
+    ExecuteRequest, InspectRequest, UpgradeRequest, UploadRequestStream,
+    artifex_client::ArtifexClient,
+};
 use futures_util::StreamExt;
 use humantime::format_duration;
 use std::{fmt::Write, time::Duration};
@@ -67,6 +70,15 @@ where
                     )?;
                 }
                 CommandStatus::Success(Some(CommandOutput::String(output)))
+            }
+            Command::Upload(path) => {
+                let stream = UploadRequestStream::create(path.clone())?;
+                let response = self.client.upload(stream).await?;
+                let reply = response.into_inner();
+                CommandStatus::Success(Some(CommandOutput::String(format!(
+                    "Uploaded as {}",
+                    reply.file_path
+                ))))
             }
         };
         Ok(status)

--- a/artifex-batch/src/runner.rs
+++ b/artifex-batch/src/runner.rs
@@ -9,15 +9,16 @@ use crate::{
     command::{Command, CommandOutput, CommandStatus},
     error::Error,
     report::{BatchReport, ReportEntry},
+    upload_progress::UploadProgress,
 };
-
 use artifex_rpc::{
     ExecuteRequest, InspectRequest, UpgradeRequest, UploadRequestStream,
     artifex_client::ArtifexClient,
 };
 use futures_util::StreamExt;
 use humantime::format_duration;
-use std::{fmt::Write, time::Duration};
+use std::{fmt::Write, sync::Arc, time::Duration};
+use tokio::task::spawn_blocking;
 use uuid::Uuid;
 
 /// Run commands via a client.
@@ -72,8 +73,21 @@ where
                 CommandStatus::Success(Some(CommandOutput::String(output)))
             }
             Command::Upload(path) => {
+                let file_metadata = std::fs::metadata(path)?;
+                let file_size = file_metadata.len();
+
                 let stream = UploadRequestStream::create(path.clone())?;
-                let response = self.client.upload(stream).await?;
+                let progress_callback = Arc::new(|progress| {
+                    // Use spawn_blocking to safely print from async context
+                    spawn_blocking(move || {
+                        println!("Upload progress: {progress}%");
+                    });
+                });
+
+                let progress_stream =
+                    UploadProgress::new(stream, file_size, Some(progress_callback));
+
+                let response = self.client.upload(progress_stream).await?;
                 let reply = response.into_inner();
                 CommandStatus::Success(Some(CommandOutput::String(format!(
                     "Uploaded as {}",

--- a/artifex-batch/src/upload_progress.rs
+++ b/artifex-batch/src/upload_progress.rs
@@ -1,0 +1,237 @@
+//
+// Copyright (C) 2022-2026 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+use artifex_rpc::{TransferChunk, UploadRequest, upload_request::Payload};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio_stream::Stream;
+
+/// Wrapper stream that adds progress tracking to upload streams.
+///
+/// This wrapper adds progress reporting to any stream of `UploadRequest` items.
+/// The progress callback is called as items are processed by the stream.
+///
+/// # Async Safety
+///
+/// The progress callback is invoked from within the async stream's `poll_next` method.
+/// Callbacks should avoid blocking operations. Use `tokio::spawn_blocking` for
+/// synchronous I/O operations like printing or file access.
+pub struct UploadProgress<S> {
+    inner: S,
+    file_size: u64,
+    bytes_uploaded: u64,
+    progress_callback: Option<Arc<dyn Fn(u8) + Send + Sync>>,
+}
+
+impl<S> UploadProgress<S>
+where
+    S: Stream<Item = UploadRequest> + Unpin,
+{
+    /// Create a new upload progress tracker
+    ///
+    /// # Arguments
+    /// * `inner` - The underlying upload request stream
+    /// * `file_size` - Total size of the file being uploaded in bytes
+    /// * `progress_callback` - Optional callback that receives progress percentage (0-100)
+    ///
+    /// # Async Context
+    ///
+    /// The callback is called from within the stream's `poll_next` method, which executes
+    /// in an async context. If the callback performs blocking I/O operations (like printing
+    /// to stdout), consider using `tokio::spawn_blocking` to avoid blocking the async runtime:
+    ///
+    /// ```no_run
+    /// use std::sync::Arc;
+    /// use tokio::task::spawn_blocking;
+    ///
+    /// let progress_callback = Arc::new(|progress: u8| {
+    ///     spawn_blocking(move || {
+    ///         println!("Progress: {}%", progress);
+    ///     });
+    /// });
+    /// ```
+    pub fn new(
+        inner: S,
+        file_size: u64,
+        progress_callback: Option<Arc<dyn Fn(u8) + Send + Sync>>,
+    ) -> Self {
+        Self {
+            inner,
+            file_size,
+            bytes_uploaded: 0,
+            progress_callback,
+        }
+    }
+}
+
+impl<S> Stream for UploadProgress<S>
+where
+    S: Stream<Item = UploadRequest> + Unpin,
+{
+    type Item = UploadRequest;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let item = match Pin::new(&mut self.inner).poll_next(cx) {
+            Poll::Ready(Some(item)) => item,
+            Poll::Ready(None) => {
+                // When stream ends, report 100% progress for empty files
+                if self.file_size == 0
+                    && let Some(callback) = &self.progress_callback
+                {
+                    callback(100);
+                }
+                return Poll::Ready(None);
+            }
+            Poll::Pending => return Poll::Pending,
+        };
+
+        // Update progress for chunk items
+        if let Some(Payload::Chunk(TransferChunk { data })) = &item.payload {
+            self.bytes_uploaded += data.len() as u64;
+
+            // Calculate progress percentage (0-100)
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let progress = if self.file_size > 0 {
+                ((self.bytes_uploaded as f64 / self.file_size as f64) * 100.0) as u8
+            } else {
+                100 // Empty file is 100% uploaded
+            };
+
+            if let Some(callback) = &self.progress_callback {
+                callback(progress);
+            }
+        }
+
+        Poll::Ready(Some(item))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use artifex_rpc::{Digest, DigestKind, TransferEpilogue, TransferPrologue};
+    use futures_util::StreamExt;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicU8, Ordering},
+    };
+
+    #[tokio::test]
+    async fn test_progress_tracking() {
+        let progress_values = Arc::new(AtomicU8::new(0));
+        let callback = Arc::new({
+            let progress_values = progress_values.clone();
+            move |progress| {
+                progress_values.store(progress, Ordering::SeqCst);
+            }
+        });
+
+        // Create mock stream that simulates uploading a 1000-byte file
+        let mock_stream = futures_util::stream::iter(vec![
+            UploadRequest {
+                payload: Some(Payload::Prologue(TransferPrologue {
+                    file_name: "test.txt".to_string(),
+                    file_size: 1000,
+                })),
+            },
+            UploadRequest {
+                payload: Some(Payload::Chunk(TransferChunk {
+                    data: vec![0; 500], // 50% progress
+                })),
+            },
+            UploadRequest {
+                payload: Some(Payload::Chunk(TransferChunk {
+                    data: vec![0; 300], // 80% progress
+                })),
+            },
+            UploadRequest {
+                payload: Some(Payload::Epilogue(TransferEpilogue {
+                    digest: Some(Digest {
+                        kind: DigestKind::Blake3.into(),
+                        data: vec![0; 32],
+                    }),
+                })),
+            },
+        ]);
+
+        let progress_stream = UploadProgress::new(mock_stream, 1000, Some(callback));
+
+        // Consume the stream
+        let items: Vec<_> = progress_stream.collect().await;
+
+        // Verify final progress was 80%
+        assert_eq!(progress_values.load(Ordering::SeqCst), 80);
+        assert_eq!(items.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_empty_file() {
+        let progress_values = Arc::new(AtomicU8::new(0));
+        let callback = Arc::new({
+            let progress_values = progress_values.clone();
+            move |progress| {
+                progress_values.store(progress, Ordering::SeqCst);
+            }
+        });
+
+        // Empty file stream
+        let mock_stream = futures_util::stream::iter(vec![
+            UploadRequest {
+                payload: Some(Payload::Prologue(TransferPrologue {
+                    file_name: "empty.txt".to_string(),
+                    file_size: 0,
+                })),
+            },
+            UploadRequest {
+                payload: Some(Payload::Epilogue(TransferEpilogue {
+                    digest: Some(Digest {
+                        kind: DigestKind::Blake3.into(),
+                        data: vec![0; 32],
+                    }),
+                })),
+            },
+        ]);
+
+        let progress_stream = UploadProgress::new(mock_stream, 0, Some(callback));
+
+        let items: Vec<_> = progress_stream.collect().await;
+
+        // Empty file should report 100% progress
+        assert_eq!(progress_values.load(Ordering::SeqCst), 100);
+        assert_eq!(items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_no_callback() {
+        // Test that it works without a callback
+        let mock_stream = futures_util::stream::iter(vec![
+            UploadRequest {
+                payload: Some(Payload::Prologue(TransferPrologue {
+                    file_name: "test.txt".to_string(),
+                    file_size: 100,
+                })),
+            },
+            UploadRequest {
+                payload: Some(Payload::Chunk(TransferChunk { data: vec![0; 50] })),
+            },
+        ]);
+
+        let progress_stream = UploadProgress::new(
+            mock_stream,
+            100,
+            None, // No callback
+        );
+
+        // Should work fine without callback
+        let items: Vec<_> = progress_stream.collect().await;
+        assert_eq!(items.len(), 2);
+    }
+}

--- a/artifex-rpc/Cargo.toml
+++ b/artifex-rpc/Cargo.toml
@@ -7,11 +7,13 @@ license.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 prost = "0.14"
+tokio = { version = "1.52", default-features = false }
 tonic = { version = "0.14", default-features = false, features = ["codegen"] }
 tonic-prost = "0.14"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 prost = "0.14"
+tokio = { workspace = true }
 tonic = "0.14"
 tonic-prost = "0.14"
 
@@ -28,3 +30,9 @@ too_many_lines = "allow"
 
 [lints.rust]
 non_camel_case_types = "allow"
+
+[dependencies]
+blake3 = "1.8.5"
+futures = { workspace = true }
+tokio-fs = "0.1.7"
+tokio-stream = "0.1.18"

--- a/artifex-rpc/Cargo.toml
+++ b/artifex-rpc/Cargo.toml
@@ -35,4 +35,4 @@ non_camel_case_types = "allow"
 blake3 = "1.8.5"
 futures = { workspace = true }
 tokio-fs = "0.1.7"
-tokio-stream = "0.1.18"
+tokio-stream = { workspace = true }

--- a/artifex-rpc/proto/artifex.proto
+++ b/artifex-rpc/proto/artifex.proto
@@ -16,6 +16,8 @@ service Artifex {
   rpc Execute(ExecuteRequest) returns (ExecuteReply) {}
   // Upgrade a the system of a machine
   rpc Upgrade(UpgradeRequest) returns (stream UpgradeReply) {}
+  // Upload a file in the cache of a machine.
+  rpc Upload(stream UploadRequest) returns (UploadResponse);
 }
 
 message InspectRequest {}
@@ -54,4 +56,56 @@ message UpgradeReply {
   }
   Status status = 1;
   int32 position = 2;
+}
+
+// Request streamed when uploading a file.
+message UploadRequest {
+  // Payload of the streamed request.
+  oneof payload {
+    TransferPrologue prologue = 1;
+    TransferChunk chunk = 2;
+    TransferEpilogue epilogue = 3;
+    TransferError error = 4;
+  }
+}
+
+enum DigestKind {
+  BLAKE3 = 0;
+}
+
+message Digest {
+  DigestKind kind = 1;
+  bytes data = 2;
+}
+
+// Prologue when transfering a file.
+message TransferPrologue {
+  // Name of the file being transfered.
+  string file_name = 1;
+  // Size of the file being transfered.
+  uint64 file_size = 2;
+}
+
+// Chunk of data when transfering a file.
+message TransferChunk {
+  // Data from the file being transfered.
+  bytes data = 1;
+}
+
+// Epilogue when transferring a file.
+message TransferEpilogue {
+  // Digest of the file transferred.
+  Digest digest = 1;
+}
+
+// Error when transferring a file.
+message TransferError {
+  // Reason for the error.
+  string reason = 1;
+}
+
+// Reply when uploading a file.
+message UploadResponse {
+  string file_path = 1;
+  uint64 file_size = 2;
 }

--- a/artifex-rpc/src/lib.rs
+++ b/artifex-rpc/src/lib.rs
@@ -8,3 +8,7 @@ tonic::include_proto!("artifex");
 
 #[cfg(not(target_arch = "wasm32"))]
 pub const FILE_DESCRIPTOR_SET: &[u8] = tonic::include_file_descriptor_set!("artifex_descriptor");
+
+mod upload_request_stream;
+
+pub use upload_request_stream::UploadRequestStream;

--- a/artifex-rpc/src/upload_request_stream.rs
+++ b/artifex-rpc/src/upload_request_stream.rs
@@ -1,0 +1,121 @@
+//
+// Copyright (C) 2022-2026 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! File upload stream management.
+
+use blake3::Hasher;
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+use tokio_stream::Stream;
+
+use crate::{
+    Digest, DigestKind, TransferChunk, TransferEpilogue, TransferError, TransferPrologue,
+    UploadRequest, upload_request::Payload,
+};
+
+/// State of the file upload.
+#[derive(Debug)]
+enum UploadState {
+    Begin,
+    Send,
+    End,
+    Error,
+}
+
+/// Generate a stream of `UploadRequest`.
+#[derive(Debug)]
+pub struct UploadRequestStream {
+    /// File to upload.
+    file: File,
+    /// Name of the file to upload.
+    file_name: String,
+    /// Size of the file to upload.
+    file_size: u64,
+    /// Hasher for the file to upload.
+    hasher: Hasher,
+    /// State of the file upload.
+    state: UploadState,
+}
+
+impl UploadRequestStream {
+    const BUFFER_SIZE: usize = 128 * 1024;
+    /// Create a new `UploadRequestStream` for file at `path`.
+    fn new<P: AsRef<Path>>(path: P) -> Result<Self, std::io::Error> {
+        let path = path.as_ref();
+        let file_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .ok_or(std::io::Error::other("Invalid file name"))?;
+        let file = File::open(path)?;
+        let file_size = file.metadata().map(|m| m.len())?;
+        let hasher = Hasher::new();
+        let state = UploadState::Begin;
+        Ok(Self {
+            file,
+            file_name,
+            file_size,
+            hasher,
+            state,
+        })
+    }
+    /// Create a [`tokio_stream::Stream`] of `UploadRequest` for file at `path`.
+    pub fn create<P: AsRef<Path>>(
+        path: P,
+    ) -> Result<impl Stream<Item = UploadRequest>, std::io::Error> {
+        let it = UploadRequestStream::new(path)?;
+        Ok(tokio_stream::iter(it))
+    }
+}
+
+impl Iterator for UploadRequestStream {
+    type Item = UploadRequest;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.state {
+            UploadState::Begin => {
+                self.state = UploadState::Send;
+                let payload = Some(Payload::Prologue(TransferPrologue {
+                    file_name: self.file_name.clone(),
+                    file_size: self.file_size,
+                }));
+                Some(UploadRequest { payload })
+            }
+            UploadState::Send => {
+                let mut data = vec![0; Self::BUFFER_SIZE];
+                let payload = match self.file.read(&mut data) {
+                    Ok(count) => {
+                        if count == 0 {
+                            let hash = self.hasher.finalize();
+                            let digest = Digest {
+                                kind: DigestKind::Blake3.into(),
+                                data: hash.as_slice().to_vec(),
+                            };
+                            self.state = UploadState::End;
+                            Payload::Epilogue(TransferEpilogue {
+                                digest: Some(digest),
+                            })
+                        } else {
+                            data.truncate(count);
+                            self.hasher.update(&data);
+                            Payload::Chunk(TransferChunk { data: data.clone() })
+                        }
+                    }
+                    Err(e) => {
+                        self.state = UploadState::Error;
+                        Payload::Error(TransferError {
+                            reason: e.to_string(),
+                        })
+                    }
+                };
+                Some(UploadRequest {
+                    payload: Some(payload),
+                })
+            }
+            UploadState::End | UploadState::Error => None,
+        }
+    }
+}

--- a/artifex-server/Cargo.toml
+++ b/artifex-server/Cargo.toml
@@ -22,6 +22,8 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+blake3 = "1.8.5"
+hex = "0.4.3"
 
 [lints]
 workspace = true

--- a/artifex-server/src/lib.rs
+++ b/artifex-server/src/lib.rs
@@ -8,3 +8,4 @@ pub mod config;
 pub mod error;
 pub mod service;
 pub mod tls;
+pub mod upload_session;

--- a/artifex-server/src/main.rs
+++ b/artifex-server/src/main.rs
@@ -65,6 +65,12 @@ async fn main() -> Result<()> {
         Config::default()
     };
 
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init()
+        .with_context(|| "Failed to init tracing")?;
+
     let tls = if args.insecure {
         None
     } else {
@@ -87,12 +93,6 @@ async fn main() -> Result<()> {
     let reflection = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
         .build_v1()?;
-
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
-        .with(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init()
-        .with_context(|| "Failed to init tracing")?;
 
     let builder = Server::builder();
     let builder = if let Some(tls) = tls {

--- a/artifex-server/src/service.rs
+++ b/artifex-server/src/service.rs
@@ -6,17 +6,23 @@
 
 use artifex_engine::{Config, Engine};
 use artifex_rpc::{
-    ExecuteReply, ExecuteRequest, InspectReply, InspectRequest, UpgradeReply, UpgradeRequest,
-    artifex_server::Artifex, upgrade_reply,
+    Digest, ExecuteReply, ExecuteRequest, InspectReply, InspectRequest, TransferEpilogue,
+    UpgradeReply, UpgradeRequest, UploadRequest, UploadResponse, artifex_server::Artifex,
+    upgrade_reply, upload_request::Payload,
 };
 
 use futures::Stream;
+use std::fs;
+use std::path::Path;
 use std::sync::Mutex;
 use std::{pin::Pin, sync::Arc};
 use tokio::sync::mpsc;
 use tokio::task;
 use tokio_stream::wrappers::ReceiverStream;
-use tonic::{Request, Response, Status};
+use tonic::{Request, Response, Status, Streaming};
+use tracing::{debug, error, warn};
+
+use crate::upload_session::UploadSession;
 
 #[derive(Default)]
 pub struct ArtifexService {
@@ -109,5 +115,81 @@ impl Artifex for ArtifexService {
 
         let ostream = ReceiverStream::new(rx);
         Ok(Response::new(Box::pin(ostream) as Self::UpgradeStream))
+    }
+    /// Upload a file on a machine.
+    async fn upload(
+        &self,
+        request: Request<Streaming<UploadRequest>>,
+    ) -> Result<Response<UploadResponse>, Status> {
+        let mut session: Option<UploadSession> = None;
+        let mut file_path = None;
+        let mut istream = request.into_inner();
+        while let Some(request) = istream.message().await? {
+            match request.payload {
+                Some(Payload::Prologue(prologue)) => {
+                    debug!("Received transfer prologue {prologue:?}");
+                    session = UploadSession::new(
+                        &prologue.file_name,
+                        prologue.file_size,
+                        Path::new("/tmp"),
+                    )
+                    .await
+                    .map(Some)
+                    .map_err(|e| Status::internal(format!("Failed to upload session: {e}")))?;
+                }
+                Some(Payload::Chunk(chunk)) => {
+                    if let Some(session) = session.as_mut() {
+                        session
+                            .write_chunk(&chunk.data)
+                            .await
+                            .map_err(|e| Status::internal(format!("Failed to write chunk: {e}")))?;
+                    } else {
+                        return Err(Status::internal("No upload session available"));
+                    }
+                }
+                Some(Payload::Epilogue(TransferEpilogue {
+                    digest: Some(digest),
+                })) => {
+                    debug!("Received transfer epilogue with digest {digest:?}");
+                    if let Some(session) = session.as_mut() {
+                        let Digest {
+                            kind: _,
+                            data: expected_hash,
+                        } = digest;
+                        file_path = session
+                            .finalize(expected_hash.as_slice())
+                            .await
+                            .map(Some)
+                            .map_err(|e| Status::internal(e.to_string()))?;
+                    } else {
+                        return Err(Status::internal("No upload session available"));
+                    }
+                    break;
+                }
+                Some(Payload::Epilogue(TransferEpilogue { digest: _ })) => {
+                    return Err(Status::internal("No digest received"));
+                }
+                Some(Payload::Error(error)) => {
+                    error!("client-side error: {}", error.reason);
+                    return Err(Status::internal(error.reason));
+                }
+                None => {
+                    warn!("No payload received");
+                }
+            }
+        }
+        if let Some(file_path) = file_path {
+            let file_size = fs::metadata(&file_path)
+                .map_err(|e| Status::internal(format!("Failed to get uploaded file size: {e}")))
+                .map(|m| m.len())?;
+            let file_path = file_path.to_string_lossy().to_string();
+            debug!("Uploaded as {file_path} ({file_size} bytes)");
+            Ok(Response::new(UploadResponse {
+                file_path,
+                file_size,
+            }))
+        } else {
+            Err(Status::internal("No file created"))
+        }
     }
 }

--- a/artifex-server/src/upload_session.rs
+++ b/artifex-server/src/upload_session.rs
@@ -1,0 +1,100 @@
+//
+// Copyright (C) 2022-2026 Eric Le Bihan <eric.le.bihan.dev@free.fr>
+//
+// SPDX-License-Identifier: MIT
+//
+
+//! File upload session management.
+
+use blake3::Hasher;
+use hex;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tokio::fs::{self, File};
+use tokio::io::AsyncWriteExt;
+use tracing::debug;
+
+/// Errors reported during an upload session.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Hash mismatch: expected {0}, computed {1}")]
+    HashMismatch(String, String),
+    #[error("Invalid file name: {0}")]
+    InvalidFileName(String),
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("Size mismatch: expected {0}, received {1}")]
+    SizeMismatch(u64, u64),
+}
+
+/// Hold information about a file upload session.
+#[derive(Debug)]
+pub struct UploadSession {
+    file: File,
+    expected_size: u64,
+    received_size: u64,
+    hasher: Hasher,
+    temp_path: PathBuf,
+    final_path: PathBuf,
+}
+
+impl UploadSession {
+    /// Create a new `UploadSession`.
+    pub async fn new(
+        file_name: &str,
+        expected_size: u64,
+        upload_dir: &Path,
+    ) -> Result<Self, Error> {
+        let file_name = Path::new(file_name)
+            .file_name()
+            .ok_or(Error::InvalidFileName(file_name.to_string()))
+            .map(|n| n.to_string_lossy())?;
+        let final_path = upload_dir.join(file_name.as_ref());
+        let temp_path = upload_dir.join(format!("{file_name}.part"));
+        let file = File::create(&temp_path).await?;
+        let hasher = Hasher::new();
+        debug!("Creating upload session file {}", temp_path.display());
+        Ok(Self {
+            file,
+            expected_size,
+            hasher,
+            received_size: 0,
+            temp_path,
+            final_path,
+        })
+    }
+    /// Write a chunk of data from uploaded file.
+    pub async fn write_chunk(&mut self, data: &[u8]) -> Result<(), Error> {
+        let () = self.file.write_all(data).await?;
+        self.hasher.update(data);
+        self.received_size += data.len() as u64;
+        Ok(())
+    }
+    /// Finalize upload session, comparing the computed hash to the expected value.
+    pub async fn finalize(&mut self, expected_hash: &[u8]) -> Result<PathBuf, Error> {
+        if self.expected_size != self.received_size {
+            return Err(Error::SizeMismatch(self.expected_size, self.received_size));
+        }
+        let computed_hash = self.hasher.finalize();
+        let computed_hash = computed_hash.as_slice();
+        if computed_hash != expected_hash {
+            return Err(Error::HashMismatch(
+                hex::encode(expected_hash),
+                hex::encode(computed_hash),
+            ));
+        }
+        fs::rename(&self.temp_path, &self.final_path).await?;
+        debug!(
+            "Renamed {} to {}",
+            self.temp_path.display(),
+            self.final_path.display()
+        );
+        Ok(self.final_path.clone())
+    }
+}
+
+impl Drop for UploadSession {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.temp_path);
+    }
+}


### PR DESCRIPTION
This patch set adds support for uploading a file to the machine running the server by:

- Adding a new gRPC method named  `artifex.UploadFile()`.
- Adding a new batch command named `UPLOAD`.
